### PR TITLE
Expose spline parameters to python bindings

### DIFF
--- a/mjpc/grpc/agent.proto
+++ b/mjpc/grpc/agent.proto
@@ -25,6 +25,8 @@ service Agent {
   rpc SetState(SetStateRequest) returns (SetStateResponse);
   // Get the current action from the Agent.
   rpc GetAction(GetActionRequest) returns (GetActionResponse);
+  // Get the current policy parameters from the Agent.
+  rpc GetSamplingPolicyParameters(GetSamplingPolicyParametersRequest) returns (GetSamplingPolicyParametersResponse);
   // Compute one plan step.
   rpc PlannerStep(PlannerStepRequest) returns (PlannerStepResponse);
   // Step physics once, using actions from the planner.
@@ -113,6 +115,11 @@ message GetActionRequest {
 
 message GetActionResponse {
   repeated float action = 1 [packed = true];
+}
+
+message GetSamplingPolicyParametersRequest {}
+message GetSamplingPolicyParametersResponse{
+  repeated double sampling_policy_parameters = 1 [packed = true];
 }
 
 message GetResidualsRequest {}

--- a/mjpc/grpc/agent.proto
+++ b/mjpc/grpc/agent.proto
@@ -26,7 +26,7 @@ service Agent {
   // Get the current action from the Agent.
   rpc GetAction(GetActionRequest) returns (GetActionResponse);
   // Get the current policy parameters from the Agent.
-  rpc GetSamplingPolicyParameters(GetSamplingPolicyParametersRequest) returns (GetSamplingPolicyParametersResponse);
+  rpc GetPolicyParameters(GetPolicyParametersRequest) returns (GetPolicyParametersResponse);
   // Compute one plan step.
   rpc PlannerStep(PlannerStepRequest) returns (PlannerStepResponse);
   // Step physics once, using actions from the planner.
@@ -117,9 +117,9 @@ message GetActionResponse {
   repeated float action = 1 [packed = true];
 }
 
-message GetSamplingPolicyParametersRequest {}
-message GetSamplingPolicyParametersResponse{
-  repeated double sampling_policy_parameters = 1 [packed = true];
+message GetPolicyParametersRequest {}
+message GetPolicyParametersResponse{
+  repeated double policy_parameters = 1 [packed = true];
 }
 
 message GetResidualsRequest {}

--- a/mjpc/grpc/agent_service.cc
+++ b/mjpc/grpc/agent_service.cc
@@ -27,348 +27,399 @@
 #include "mjpc/task.h"
 #include "mjpc/trajectory.h"
 
-namespace mjpc::agent_grpc {
+namespace mjpc::agent_grpc
+{
 
-using ::agent::GetActionRequest;
-using ::agent::GetActionResponse;
-using ::agent::GetAllModesRequest;
-using ::agent::GetAllModesResponse;
-using ::agent::GetBestTrajectoryRequest;
-using ::agent::GetBestTrajectoryResponse;
-using ::agent::GetResidualsRequest;
-using ::agent::GetResidualsResponse;
-using ::agent::GetCostValuesAndWeightsRequest;
-using ::agent::GetCostValuesAndWeightsResponse;
-using ::agent::GetModeRequest;
-using ::agent::GetModeResponse;
-using ::agent::GetSamplingPolicyParametersRequest;
-using ::agent::GetSamplingPolicyParametersResponse;
-using ::agent::GetStateRequest;
-using ::agent::GetStateResponse;
-using ::agent::GetTaskParametersRequest;
-using ::agent::GetTaskParametersResponse;
-using ::agent::InitRequest;
-using ::agent::InitResponse;
-using ::agent::PlannerStepRequest;
-using ::agent::PlannerStepResponse;
-using ::agent::ResetRequest;
-using ::agent::ResetResponse;
-using ::agent::SetAnythingRequest;
-using ::agent::SetAnythingResponse;
-using ::agent::SetCostWeightsRequest;
-using ::agent::SetCostWeightsResponse;
-using ::agent::SetModeRequest;
-using ::agent::SetModeResponse;
-using ::agent::SetStateRequest;
-using ::agent::SetStateResponse;
-using ::agent::SetTaskParametersRequest;
-using ::agent::SetTaskParametersResponse;
-using ::agent::StepRequest;
-using ::agent::StepResponse;
+  using ::agent::GetActionRequest;
+  using ::agent::GetActionResponse;
+  using ::agent::GetAllModesRequest;
+  using ::agent::GetAllModesResponse;
+  using ::agent::GetBestTrajectoryRequest;
+  using ::agent::GetBestTrajectoryResponse;
+  using ::agent::GetCostValuesAndWeightsRequest;
+  using ::agent::GetCostValuesAndWeightsResponse;
+  using ::agent::GetModeRequest;
+  using ::agent::GetModeResponse;
+  using ::agent::GetPolicyParametersRequest;
+  using ::agent::GetPolicyParametersResponse;
+  using ::agent::GetResidualsRequest;
+  using ::agent::GetResidualsResponse;
+  using ::agent::GetStateRequest;
+  using ::agent::GetStateResponse;
+  using ::agent::GetTaskParametersRequest;
+  using ::agent::GetTaskParametersResponse;
+  using ::agent::InitRequest;
+  using ::agent::InitResponse;
+  using ::agent::PlannerStepRequest;
+  using ::agent::PlannerStepResponse;
+  using ::agent::ResetRequest;
+  using ::agent::ResetResponse;
+  using ::agent::SetAnythingRequest;
+  using ::agent::SetAnythingResponse;
+  using ::agent::SetCostWeightsRequest;
+  using ::agent::SetCostWeightsResponse;
+  using ::agent::SetModeRequest;
+  using ::agent::SetModeResponse;
+  using ::agent::SetStateRequest;
+  using ::agent::SetStateResponse;
+  using ::agent::SetTaskParametersRequest;
+  using ::agent::SetTaskParametersResponse;
+  using ::agent::StepRequest;
+  using ::agent::StepResponse;
 
-// task used to define desired behaviour
-mjpc::Task* task = nullptr;
+  // task used to define desired behaviour
+  mjpc::Task *task = nullptr;
 
-// model used for physics
-mjModel* model = nullptr;
+  // model used for physics
+  mjModel *model = nullptr;
 
-// model used for planning, owned by the Agent instance.
-mjModel* agent_model = nullptr;
+  // model used for planning, owned by the Agent instance.
+  mjModel *agent_model = nullptr;
 
-void residual_sensor_callback(const mjModel* m, mjData* d, int stage) {
-  // with the `m == model` guard in place, no need to clear the callback.
-  if (m == agent_model || m == model) {
-    if (stage == mjSTAGE_ACC) {
-      task->Residual(m, d, d->sensordata);
+  void residual_sensor_callback(const mjModel *m, mjData *d, int stage)
+  {
+    // with the `m == model` guard in place, no need to clear the callback.
+    if (m == agent_model || m == model)
+    {
+      if (stage == mjSTAGE_ACC)
+      {
+        task->Residual(m, d, d->sensordata);
+      }
     }
   }
-}
 
-grpc::Status AgentService::Init(grpc::ServerContext* context,
-                                const InitRequest* request,
-                                InitResponse* response) {
-  agent_.SetTaskList(tasks_);
-  grpc::Status status = grpc_agent_util::InitAgent(&agent_, request);
-  if (!status.ok()) {
+  grpc::Status AgentService::Init(grpc::ServerContext *context,
+                                  const InitRequest *request,
+                                  InitResponse *response)
+  {
+    agent_.SetTaskList(tasks_);
+    grpc::Status status = grpc_agent_util::InitAgent(&agent_, request);
+    if (!status.ok())
+    {
+      return status;
+    }
+    agent_.SetTaskList(tasks_);
+    std::string_view task_id = request->task_id();
+    int task_index = agent_.GetTaskIdByName(task_id);
+    if (task_index == -1)
+    {
+      return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                          absl::StrFormat("Invalid task_id: '%s'", task_id));
+    }
+    agent_.SetTaskByIndex(task_index);
+
+    auto load_model = agent_.LoadModel();
+    if (!load_model.model)
+    {
+      return grpc::Status(
+          grpc::StatusCode::INTERNAL,
+          absl::StrCat("Failed to load model: ", load_model.error));
+    }
+
+    agent_.Initialize(load_model.model.get());
+    agent_.Allocate();
+    agent_.Reset();
+
+    task = agent_.ActiveTask();
+    CHECK_EQ(agent_model, nullptr)
+        << "Multiple instances of AgentService detected.";
+    agent_model = agent_.GetModel();
+    // copy the model before agent model's timestep and integrator are updated
+    CHECK_EQ(model, nullptr)
+        << "Multiple instances of AgentService detected.";
+    model = mj_copyModel(nullptr, agent_model);
+    data_ = mj_makeData(model);
+    rollout_data_.reset(mj_makeData(model));
+    int home_id = mj_name2id(model, mjOBJ_KEY, "home");
+    if (home_id >= 0)
+    {
+      mj_resetDataKeyframe(model, data_, home_id);
+      mj_resetDataKeyframe(model, rollout_data_.get(), home_id);
+    }
+    mjcb_sensor = residual_sensor_callback;
+
+    agent_.SetState(data_);
+
+    agent_.plan_enabled = true;
+    agent_.action_enabled = true;
+
+    return grpc::Status::OK;
+  }
+
+  AgentService::~AgentService()
+  {
+    if (data_)
+      mj_deleteData(data_);
+    if (model)
+      mj_deleteModel(model);
+    model = nullptr;
+    // no need to delete agent_model and task, since they're owned by agent_.
+    agent_model = nullptr;
+    task = nullptr;
+    mjcb_sensor = nullptr;
+  }
+
+  grpc::Status AgentService::GetState(grpc::ServerContext *context,
+                                      const GetStateRequest *request,
+                                      GetStateResponse *response)
+  {
+    if (!Initialized())
+    {
+      return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
+    }
+    agent_.state.CopyTo(model, data_);
+    return grpc_agent_util::GetState(model, data_, response);
+  }
+
+  grpc::Status AgentService::SetState(grpc::ServerContext *context,
+                                      const SetStateRequest *request,
+                                      SetStateResponse *response)
+  {
+    if (!Initialized())
+    {
+      return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
+    }
+    grpc::Status status =
+        grpc_agent_util::SetState(request, &agent_, model, data_);
+    if (!status.ok())
+      return status;
+
+    mj_forward(model, data_);
+    // Further update the state by calling task's Transition function.
+    task->Transition(model, data_);
+    agent_.SetState(data_);
+
+    return grpc::Status::OK;
+  }
+
+  grpc::Status AgentService::GetAction(grpc::ServerContext *context,
+                                       const GetActionRequest *request,
+                                       GetActionResponse *response)
+  {
+    if (!Initialized())
+    {
+      return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
+    }
+    // get action
+    auto out = grpc_agent_util::GetAction(
+        request, &agent_, model, rollout_data_.get(), &rollout_state_, response);
+    // set data
+    auto action = response->action().data();
+    for (int i = 0; i < model->nu; i++)
+    {
+      data_->ctrl[i] = action[i];
+    }
+    return out;
+  }
+
+  grpc::Status AgentService::GetResiduals(
+      grpc::ServerContext *context, const GetResidualsRequest *request,
+      GetResidualsResponse *response)
+  {
+    if (!Initialized())
+    {
+      return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
+    }
+    return grpc_agent_util::GetResiduals(request, &agent_, model,
+                                         data_, response);
+  }
+
+  grpc::Status AgentService::GetCostValuesAndWeights(
+      grpc::ServerContext *context, const GetCostValuesAndWeightsRequest *request,
+      GetCostValuesAndWeightsResponse *response)
+  {
+    if (!Initialized())
+    {
+      return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
+    }
+    return grpc_agent_util::GetCostValuesAndWeights(request, &agent_, model,
+                                                    data_, response);
+  }
+
+  grpc::Status AgentService::PlannerStep(grpc::ServerContext *context,
+                                         const PlannerStepRequest *request,
+                                         PlannerStepResponse *response)
+  {
+    if (!Initialized())
+    {
+      return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
+    }
+    agent_.plan_enabled = true;
+    agent_.PlanIteration(&thread_pool_);
+
+    return grpc::Status::OK;
+  }
+
+  grpc::Status AgentService::Step(grpc::ServerContext *context,
+                                  const StepRequest *request,
+                                  StepResponse *response)
+  {
+    if (!Initialized())
+    {
+      return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
+    }
+    mjpc::State &state = agent_.state;
+    state.CopyTo(model, data_);
+    // mj_forward is needed because Transition might access properties from
+    // mjData.
+    // For performance, we could consider adding an option to the request for
+    // callers to assume that data_ is up to date before the call.
+    mj_forward(model, data_);
+    agent_.ActiveTask()->Transition(model, data_);
+    agent_.ActivePlanner().ActionFromPolicy(data_->ctrl, state.state().data(),
+                                            state.time(),
+                                            request->use_previous_policy());
+    mj_step(model, data_);
+    state.Set(model, data_);
+    return grpc::Status::OK;
+  }
+
+  grpc::Status AgentService::Reset(grpc::ServerContext *context,
+                                   const ResetRequest *request,
+                                   ResetResponse *response)
+  {
+    if (!Initialized())
+    {
+      return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
+    }
+
+    grpc::Status status =
+        grpc_agent_util::Reset(&agent_, agent_.GetModel(), data_);
+    rollout_data_.reset(mj_makeData(model));
     return status;
   }
-  agent_.SetTaskList(tasks_);
-  std::string_view task_id = request->task_id();
-  int task_index = agent_.GetTaskIdByName(task_id);
-  if (task_index == -1) {
-    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                        absl::StrFormat("Invalid task_id: '%s'", task_id));
-  }
-  agent_.SetTaskByIndex(task_index);
 
-  auto load_model = agent_.LoadModel();
-  if (!load_model.model) {
-    return grpc::Status(
-        grpc::StatusCode::INTERNAL,
-        absl::StrCat("Failed to load model: ", load_model.error));
+  grpc::Status AgentService::SetTaskParameters(
+      grpc::ServerContext *context, const SetTaskParametersRequest *request,
+      SetTaskParametersResponse *response)
+  {
+    if (!Initialized())
+    {
+      return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
+    }
+    return grpc_agent_util::SetTaskParameters(request, &agent_);
   }
 
-  agent_.Initialize(load_model.model.get());
-  agent_.Allocate();
-  agent_.Reset();
-
-  task = agent_.ActiveTask();
-  CHECK_EQ(agent_model, nullptr)
-      << "Multiple instances of AgentService detected.";
-  agent_model = agent_.GetModel();
-  // copy the model before agent model's timestep and integrator are updated
-  CHECK_EQ(model, nullptr)
-      << "Multiple instances of AgentService detected.";
-  model = mj_copyModel(nullptr, agent_model);
-  data_ = mj_makeData(model);
-  rollout_data_.reset(mj_makeData(model));
-  int home_id = mj_name2id(model, mjOBJ_KEY, "home");
-  if (home_id >= 0) {
-    mj_resetDataKeyframe(model, data_, home_id);
-    mj_resetDataKeyframe(model, rollout_data_.get(), home_id);
-  }
-  mjcb_sensor = residual_sensor_callback;
-
-  agent_.SetState(data_);
-
-  agent_.plan_enabled = true;
-  agent_.action_enabled = true;
-
-  return grpc::Status::OK;
-}
-
-AgentService::~AgentService() {
-  if (data_) mj_deleteData(data_);
-  if (model) mj_deleteModel(model);
-  model = nullptr;
-  // no need to delete agent_model and task, since they're owned by agent_.
-  agent_model = nullptr;
-  task = nullptr;
-  mjcb_sensor = nullptr;
-}
-
-grpc::Status AgentService::GetState(grpc::ServerContext* context,
-                                    const GetStateRequest* request,
-                                    GetStateResponse* response) {
-  if (!Initialized()) {
-    return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
-  }
-  agent_.state.CopyTo(model, data_);
-  return grpc_agent_util::GetState(model, data_, response);
-}
-
-grpc::Status AgentService::SetState(grpc::ServerContext* context,
-                                    const SetStateRequest* request,
-                                    SetStateResponse* response) {
-  if (!Initialized()) {
-    return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
-  }
-  grpc::Status status =
-      grpc_agent_util::SetState(request, &agent_, model, data_);
-  if (!status.ok()) return status;
-
-  mj_forward(model, data_);
-  // Further update the state by calling task's Transition function.
-  task->Transition(model, data_);
-  agent_.SetState(data_);
-
-  return grpc::Status::OK;
-}
-
-grpc::Status AgentService::GetAction(grpc::ServerContext* context,
-                                     const GetActionRequest* request,
-                                     GetActionResponse* response) {
-  if (!Initialized()) {
-    return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
-  }
-  // get action
-  auto out = grpc_agent_util::GetAction(
-      request, &agent_, model, rollout_data_.get(), &rollout_state_, response);
-  // set data
-  auto action = response->action().data();
-  for (int i = 0; i < model->nu; i++) {
-    data_->ctrl[i] = action[i];
-  }
-  return out;
-}
-
-grpc::Status AgentService::GetResiduals(
-    grpc::ServerContext* context, const GetResidualsRequest* request,
-    GetResidualsResponse* response) {
-  if (!Initialized()) {
-    return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
-  }
-  return grpc_agent_util::GetResiduals(request, &agent_, model,
-                                       data_, response);
-}
-
-grpc::Status AgentService::GetCostValuesAndWeights(
-    grpc::ServerContext* context, const GetCostValuesAndWeightsRequest* request,
-    GetCostValuesAndWeightsResponse* response) {
-  if (!Initialized()) {
-    return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
-  }
-  return grpc_agent_util::GetCostValuesAndWeights(request, &agent_, model,
-                                                  data_, response);
-}
-
-grpc::Status AgentService::PlannerStep(grpc::ServerContext* context,
-                                       const PlannerStepRequest* request,
-                                       PlannerStepResponse* response) {
-  if (!Initialized()) {
-    return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
-  }
-  agent_.plan_enabled = true;
-  agent_.PlanIteration(&thread_pool_);
-
-  return grpc::Status::OK;
-}
-
-grpc::Status AgentService::Step(grpc::ServerContext* context,
-                                const StepRequest* request,
-                                StepResponse* response) {
-  if (!Initialized()) {
-    return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
-  }
-  mjpc::State& state = agent_.state;
-  state.CopyTo(model, data_);
-  // mj_forward is needed because Transition might access properties from
-  // mjData.
-  // For performance, we could consider adding an option to the request for
-  // callers to assume that data_ is up to date before the call.
-  mj_forward(model, data_);
-  agent_.ActiveTask()->Transition(model, data_);
-  agent_.ActivePlanner().ActionFromPolicy(data_->ctrl, state.state().data(),
-                                          state.time(),
-                                          request->use_previous_policy());
-  mj_step(model, data_);
-  state.Set(model, data_);
-  return grpc::Status::OK;
-}
-
-grpc::Status AgentService::Reset(grpc::ServerContext* context,
-                                 const ResetRequest* request,
-                                 ResetResponse* response) {
-  if (!Initialized()) {
-    return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
+  grpc::Status AgentService::GetTaskParameters(
+      grpc::ServerContext *context, const GetTaskParametersRequest *request,
+      GetTaskParametersResponse *response)
+  {
+    if (!Initialized())
+    {
+      return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
+    }
+    return grpc_agent_util::GetTaskParameters(request, &agent_, response);
   }
 
-  grpc::Status status =
-      grpc_agent_util::Reset(&agent_, agent_.GetModel(), data_);
-  rollout_data_.reset(mj_makeData(model));
-  return status;
-}
-
-grpc::Status AgentService::SetTaskParameters(
-    grpc::ServerContext* context, const SetTaskParametersRequest* request,
-    SetTaskParametersResponse* response) {
-  if (!Initialized()) {
-    return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
-  }
-  return grpc_agent_util::SetTaskParameters(request, &agent_);
-}
-
-grpc::Status AgentService::GetTaskParameters(
-    grpc::ServerContext* context, const GetTaskParametersRequest* request,
-    GetTaskParametersResponse* response) {
-  if (!Initialized()) {
-    return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
-  }
-  return grpc_agent_util::GetTaskParameters(request, &agent_, response);
-}
-
-grpc::Status AgentService::SetCostWeights(
-    grpc::ServerContext* context, const SetCostWeightsRequest* request,
-    SetCostWeightsResponse* response) {
-  if (!Initialized()) {
-    return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
-  }
-  return grpc_agent_util::SetCostWeights(request, &agent_);
-}
-
-grpc::Status AgentService::SetMode(grpc::ServerContext* context,
-                                   const SetModeRequest* request,
-                                   SetModeResponse* response) {
-  if (!Initialized()) {
-    return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
-  }
-  return grpc_agent_util::SetMode(request, &agent_);
-}
-
-grpc::Status AgentService::GetMode(grpc::ServerContext* context,
-                                   const GetModeRequest* request,
-                                   GetModeResponse* response) {
-  if (!Initialized()) {
-    return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
-  }
-  return grpc_agent_util::GetMode(request, &agent_, response);
-}
-
-grpc::Status AgentService::GetSamplingPolicyParameters(
-    grpc::ServerContext* context, const GetSamplingPolicyParametersRequest* request,
-    GetSamplingPolicyParametersResponse* response) {
-  if (!Initialized()) {
-    return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
-  }
-  return grpc_agent_util::GetSamplingPolicyParameters(request, &agent_, response);
-}
-
-grpc::Status AgentService::GetAllModes(grpc::ServerContext* context,
-                                       const GetAllModesRequest* request,
-                                       GetAllModesResponse* response) {
-  if (!Initialized()) {
-    return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
-  }
-  return grpc_agent_util::GetAllModes(request, &agent_, response);
-}
-
-grpc::Status AgentService::GetBestTrajectory(
-    grpc::ServerContext* context, const GetBestTrajectoryRequest* request,
-    GetBestTrajectoryResponse* response) {
-  if (!Initialized()) {
-    return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
+  grpc::Status AgentService::SetCostWeights(
+      grpc::ServerContext *context, const SetCostWeightsRequest *request,
+      SetCostWeightsResponse *response)
+  {
+    if (!Initialized())
+    {
+      return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
+    }
+    return grpc_agent_util::SetCostWeights(request, &agent_);
   }
 
-  // get best trajectory
-  const Trajectory* trajectory = agent_.ActivePlanner().BestTrajectory();
+  grpc::Status AgentService::SetMode(grpc::ServerContext *context,
+                                     const SetModeRequest *request,
+                                     SetModeResponse *response)
+  {
+    if (!Initialized())
+    {
+      return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
+    }
+    return grpc_agent_util::SetMode(request, &agent_);
+  }
 
-  // dimensions
-  int num_state = trajectory->dim_state;
-  int num_action = trajectory->dim_action;
+  grpc::Status AgentService::GetMode(grpc::ServerContext *context,
+                                     const GetModeRequest *request,
+                                     GetModeResponse *response)
+  {
+    if (!Initialized())
+    {
+      return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
+    }
+    return grpc_agent_util::GetMode(request, &agent_, response);
+  }
 
-  // plan steps
-  int steps = agent_.PlanSteps();
-  response->set_steps(steps);
+  grpc::Status AgentService::GetPolicyParameters(
+      grpc::ServerContext *context, const GetPolicyParametersRequest *request,
+      GetPolicyParametersResponse *response)
+  {
+    if (!Initialized())
+    {
+      return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
+    }
+    return grpc_agent_util::GetPolicyParameters(request, &agent_, response);
+  }
 
-  // loop over plan steps
-  for (int t = 0; t < steps; t++) {
-    // states
-    for (int i = 0; i < num_state; i++) {
-      response->add_states(trajectory->states[t * num_state + i]);
+  grpc::Status AgentService::GetAllModes(grpc::ServerContext *context,
+                                         const GetAllModesRequest *request,
+                                         GetAllModesResponse *response)
+  {
+    if (!Initialized())
+    {
+      return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
+    }
+    return grpc_agent_util::GetAllModes(request, &agent_, response);
+  }
+
+  grpc::Status AgentService::GetBestTrajectory(
+      grpc::ServerContext *context, const GetBestTrajectoryRequest *request,
+      GetBestTrajectoryResponse *response)
+  {
+    if (!Initialized())
+    {
+      return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
     }
 
-    // times
-    response->add_times(trajectory->times[t]);
+    // get best trajectory
+    const Trajectory *trajectory = agent_.ActivePlanner().BestTrajectory();
 
-    // actions
-    if (t >= steps - 1) continue;
-    for (int i = 0; i < num_action; i++) {
-      response->add_actions(trajectory->actions[t * num_action + i]);
+    // dimensions
+    int num_state = trajectory->dim_state;
+    int num_action = trajectory->dim_action;
+
+    // plan steps
+    int steps = agent_.PlanSteps();
+    response->set_steps(steps);
+
+    // loop over plan steps
+    for (int t = 0; t < steps; t++)
+    {
+      // states
+      for (int i = 0; i < num_state; i++)
+      {
+        response->add_states(trajectory->states[t * num_state + i]);
+      }
+
+      // times
+      response->add_times(trajectory->times[t]);
+
+      // actions
+      if (t >= steps - 1)
+        continue;
+      for (int i = 0; i < num_action; i++)
+      {
+        response->add_actions(trajectory->actions[t * num_action + i]);
+      }
     }
+
+    // TODO(taylor): improve return status
+    return grpc::Status::OK;
   }
 
-  // TODO(taylor): improve return status
-  return grpc::Status::OK;
-}
-
-
-grpc::Status AgentService::SetAnything(
-    grpc::ServerContext* context, const SetAnythingRequest* request,
-    SetAnythingResponse* response) {
-  if (!Initialized()) {
-    return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
+  grpc::Status AgentService::SetAnything(
+      grpc::ServerContext *context, const SetAnythingRequest *request,
+      SetAnythingResponse *response)
+  {
+    if (!Initialized())
+    {
+      return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
+    }
+    return grpc_agent_util::SetAnything(request, &agent_, agent_.GetModel(),
+                                        data_, response);
   }
-  return grpc_agent_util::SetAnything(request, &agent_, agent_.GetModel(),
-                                      data_, response);
-}
-}  // namespace mjpc::agent_grpc
+} // namespace mjpc::agent_grpc

--- a/mjpc/grpc/agent_service.cc
+++ b/mjpc/grpc/agent_service.cc
@@ -41,6 +41,8 @@ using ::agent::GetCostValuesAndWeightsRequest;
 using ::agent::GetCostValuesAndWeightsResponse;
 using ::agent::GetModeRequest;
 using ::agent::GetModeResponse;
+using ::agent::GetSamplingPolicyParametersRequest;
+using ::agent::GetSamplingPolicyParametersResponse;
 using ::agent::GetStateRequest;
 using ::agent::GetStateResponse;
 using ::agent::GetTaskParametersRequest;
@@ -300,6 +302,15 @@ grpc::Status AgentService::GetMode(grpc::ServerContext* context,
     return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
   }
   return grpc_agent_util::GetMode(request, &agent_, response);
+}
+
+grpc::Status AgentService::GetSamplingPolicyParameters(
+    grpc::ServerContext* context, const GetSamplingPolicyParametersRequest* request,
+    GetSamplingPolicyParametersResponse* response) {
+  if (!Initialized()) {
+    return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
+  }
+  return grpc_agent_util::GetSamplingPolicyParameters(request, &agent_, response);
 }
 
 grpc::Status AgentService::GetAllModes(grpc::ServerContext* context,

--- a/mjpc/grpc/agent_service.h
+++ b/mjpc/grpc/agent_service.h
@@ -58,6 +58,11 @@ class AgentService final : public agent::Agent::Service {
                          const agent::GetActionRequest* request,
                          agent::GetActionResponse* response) override;
 
+  grpc::Status GetSamplingPolicyParameters(
+      grpc::ServerContext* context,
+      const agent::GetSamplingPolicyParametersRequest* request,
+      agent::GetSamplingPolicyParametersResponse* response) override;
+
   grpc::Status GetResiduals(
       grpc::ServerContext* context,
       const agent::GetResidualsRequest* request,

--- a/mjpc/grpc/agent_service.h
+++ b/mjpc/grpc/agent_service.h
@@ -31,111 +31,113 @@
 #include <mjpc/threadpool.h>
 #include <mjpc/utilities.h>
 
-namespace mjpc::agent_grpc {
+namespace mjpc::agent_grpc
+{
 
-class AgentService final : public agent::Agent::Service {
- public:
-  explicit AgentService(std::vector<std::shared_ptr<mjpc::Task>> tasks,
-                        int num_workers = -1)
-      : thread_pool_(num_workers == -1 ? mjpc::NumAvailableHardwareThreads()
-                                       : num_workers),
-        tasks_(std::move(tasks)),
-        rollout_data_(nullptr, mj_deleteData) {}
-  ~AgentService();
-  grpc::Status Init(grpc::ServerContext* context,
-                    const agent::InitRequest* request,
-                    agent::InitResponse* response) override;
+    class AgentService final : public agent::Agent::Service
+    {
+    public:
+        explicit AgentService(std::vector<std::shared_ptr<mjpc::Task>> tasks,
+                              int num_workers = -1)
+            : thread_pool_(num_workers == -1 ? mjpc::NumAvailableHardwareThreads()
+                                             : num_workers),
+              tasks_(std::move(tasks)),
+              rollout_data_(nullptr, mj_deleteData) {}
+        ~AgentService();
+        grpc::Status Init(grpc::ServerContext *context,
+                          const agent::InitRequest *request,
+                          agent::InitResponse *response) override;
 
-  grpc::Status GetState(grpc::ServerContext* context,
-                        const agent::GetStateRequest* request,
-                        agent::GetStateResponse* response) override;
+        grpc::Status GetState(grpc::ServerContext *context,
+                              const agent::GetStateRequest *request,
+                              agent::GetStateResponse *response) override;
 
-  grpc::Status SetState(grpc::ServerContext* context,
-                        const agent::SetStateRequest* request,
-                        agent::SetStateResponse* response) override;
+        grpc::Status SetState(grpc::ServerContext *context,
+                              const agent::SetStateRequest *request,
+                              agent::SetStateResponse *response) override;
 
-  grpc::Status GetAction(grpc::ServerContext* context,
-                         const agent::GetActionRequest* request,
-                         agent::GetActionResponse* response) override;
+        grpc::Status GetAction(grpc::ServerContext *context,
+                               const agent::GetActionRequest *request,
+                               agent::GetActionResponse *response) override;
 
-  grpc::Status GetSamplingPolicyParameters(
-      grpc::ServerContext* context,
-      const agent::GetSamplingPolicyParametersRequest* request,
-      agent::GetSamplingPolicyParametersResponse* response) override;
+        grpc::Status GetPolicyParameters(
+            grpc::ServerContext *context,
+            const agent::GetPolicyParametersRequest *request,
+            agent::GetPolicyParametersResponse *response) override;
 
-  grpc::Status GetResiduals(
-      grpc::ServerContext* context,
-      const agent::GetResidualsRequest* request,
-      agent::GetResidualsResponse* response) override;
+        grpc::Status GetResiduals(
+            grpc::ServerContext *context,
+            const agent::GetResidualsRequest *request,
+            agent::GetResidualsResponse *response) override;
 
-  grpc::Status GetCostValuesAndWeights(
-      grpc::ServerContext* context,
-      const agent::GetCostValuesAndWeightsRequest* request,
-      agent::GetCostValuesAndWeightsResponse* response) override;
+        grpc::Status GetCostValuesAndWeights(
+            grpc::ServerContext *context,
+            const agent::GetCostValuesAndWeightsRequest *request,
+            agent::GetCostValuesAndWeightsResponse *response) override;
 
-  grpc::Status PlannerStep(grpc::ServerContext* context,
-                           const agent::PlannerStepRequest* request,
-                           agent::PlannerStepResponse* response) override;
+        grpc::Status PlannerStep(grpc::ServerContext *context,
+                                 const agent::PlannerStepRequest *request,
+                                 agent::PlannerStepResponse *response) override;
 
-  grpc::Status Step(grpc::ServerContext* context,
-                    const agent::StepRequest* request,
-                    agent::StepResponse* response) override;
+        grpc::Status Step(grpc::ServerContext *context,
+                          const agent::StepRequest *request,
+                          agent::StepResponse *response) override;
 
-  grpc::Status Reset(grpc::ServerContext* context,
-                     const agent::ResetRequest* request,
-                     agent::ResetResponse* response) override;
+        grpc::Status Reset(grpc::ServerContext *context,
+                           const agent::ResetRequest *request,
+                           agent::ResetResponse *response) override;
 
-  grpc::Status SetTaskParameters(
-      grpc::ServerContext* context,
-      const agent::SetTaskParametersRequest* request,
-      agent::SetTaskParametersResponse* response) override;
+        grpc::Status SetTaskParameters(
+            grpc::ServerContext *context,
+            const agent::SetTaskParametersRequest *request,
+            agent::SetTaskParametersResponse *response) override;
 
-  grpc::Status GetTaskParameters(
-      grpc::ServerContext* context,
-      const agent::GetTaskParametersRequest* request,
-      agent::GetTaskParametersResponse* response) override;
+        grpc::Status GetTaskParameters(
+            grpc::ServerContext *context,
+            const agent::GetTaskParametersRequest *request,
+            agent::GetTaskParametersResponse *response) override;
 
-  grpc::Status SetCostWeights(
-      grpc::ServerContext* context,
-      const agent::SetCostWeightsRequest* request,
-      agent::SetCostWeightsResponse* response) override;
+        grpc::Status SetCostWeights(
+            grpc::ServerContext *context,
+            const agent::SetCostWeightsRequest *request,
+            agent::SetCostWeightsResponse *response) override;
 
-  grpc::Status SetMode(
-      grpc::ServerContext* context,
-      const agent::SetModeRequest* request,
-      agent::SetModeResponse* response) override;
+        grpc::Status SetMode(
+            grpc::ServerContext *context,
+            const agent::SetModeRequest *request,
+            agent::SetModeResponse *response) override;
 
-  grpc::Status GetMode(
-      grpc::ServerContext* context,
-      const agent::GetModeRequest* request,
-      agent::GetModeResponse* response) override;
+        grpc::Status GetMode(
+            grpc::ServerContext *context,
+            const agent::GetModeRequest *request,
+            agent::GetModeResponse *response) override;
 
-  grpc::Status GetAllModes(grpc::ServerContext* context,
-                           const agent::GetAllModesRequest* request,
-                           agent::GetAllModesResponse* response) override;
+        grpc::Status GetAllModes(grpc::ServerContext *context,
+                                 const agent::GetAllModesRequest *request,
+                                 agent::GetAllModesResponse *response) override;
 
-  grpc::Status GetBestTrajectory(
-      grpc::ServerContext* context,
-      const agent::GetBestTrajectoryRequest* request,
-      agent::GetBestTrajectoryResponse* response) override;
+        grpc::Status GetBestTrajectory(
+            grpc::ServerContext *context,
+            const agent::GetBestTrajectoryRequest *request,
+            agent::GetBestTrajectoryResponse *response) override;
 
-  grpc::Status SetAnything(grpc::ServerContext* context,
-                           const agent::SetAnythingRequest* request,
-                           agent::SetAnythingResponse* response) override;
+        grpc::Status SetAnything(grpc::ServerContext *context,
+                                 const agent::SetAnythingRequest *request,
+                                 agent::SetAnythingResponse *response) override;
 
- private:
-  bool Initialized() const { return data_ != nullptr; }
+    private:
+        bool Initialized() const { return data_ != nullptr; }
 
-  mjpc::ThreadPool thread_pool_;
-  mjpc::Agent agent_;
-  std::vector<std::shared_ptr<mjpc::Task>> tasks_;
-  mjData* data_ = nullptr;
+        mjpc::ThreadPool thread_pool_;
+        mjpc::Agent agent_;
+        std::vector<std::shared_ptr<mjpc::Task>> tasks_;
+        mjData *data_ = nullptr;
 
-  // an mjData instance used for rollouts for action averaging
-  mjpc::UniqueMjData rollout_data_;
-  mjpc::State rollout_state_;
-};
+        // an mjData instance used for rollouts for action averaging
+        mjpc::UniqueMjData rollout_data_;
+        mjpc::State rollout_state_;
+    };
 
-}  // namespace mjpc::agent_grpc
+} // namespace mjpc::agent_grpc
 
-#endif  // MJPC_MJPC_GRPC_AGENT_SERVICE_H_
+#endif // MJPC_MJPC_GRPC_AGENT_SERVICE_H_

--- a/mjpc/grpc/grpc_agent_util.cc
+++ b/mjpc/grpc/grpc_agent_util.cc
@@ -51,10 +51,10 @@ namespace grpc_agent_util
   using ::agent::GetCostValuesAndWeightsResponse;
   using ::agent::GetModeRequest;
   using ::agent::GetModeResponse;
+  using ::agent::GetPolicyParametersRequest;
+  using ::agent::GetPolicyParametersResponse;
   using ::agent::GetResidualsRequest;
   using ::agent::GetResidualsResponse;
-  using ::agent::GetSamplingPolicyParametersRequest;
-  using ::agent::GetSamplingPolicyParametersResponse;
   using ::agent::GetStateResponse;
   using ::agent::GetTaskParametersRequest;
   using ::agent::GetTaskParametersResponse;
@@ -269,14 +269,14 @@ namespace grpc_agent_util
     return grpc::Status::OK;
   }
 
-  grpc::Status GetSamplingPolicyParameters(const GetSamplingPolicyParametersRequest *request,
-                                           const mjpc::Agent *agent,
-                                           GetSamplingPolicyParametersResponse *response)
+  grpc::Status GetPolicyParameters(const GetPolicyParametersRequest *request,
+                                   const mjpc::Agent *agent,
+                                   GetPolicyParametersResponse *response)
   {
     mjpc::Planner &planner = agent->ActivePlanner();
     std::vector<double> parameters(planner.NumParameters(), 0);
     planner.Parameters(parameters.data());
-    response->mutable_sampling_policy_parameters()->Assign(parameters.begin(), parameters.end());
+    response->mutable_policy_parameters()->Assign(parameters.begin(), parameters.end());
 
     return grpc::Status::OK;
   }

--- a/mjpc/grpc/grpc_agent_util.cc
+++ b/mjpc/grpc/grpc_agent_util.cc
@@ -35,278 +35,344 @@
 #include "mjpc/grpc/agent.pb.h"
 #include "mjpc/agent.h"
 #include "mjpc/states/state.h"
+#include "mjpc/planners/sampling/policy.h"
+#include "mjpc/spline/spline.h"
 #include "mjpc/task.h"
 #include "mjpc/utilities.h"
 
-namespace grpc_agent_util {
+namespace grpc_agent_util
+{
 
-using ::agent::GetActionRequest;
-using ::agent::GetActionResponse;
-using ::agent::GetAllModesRequest;
-using ::agent::GetAllModesResponse;
-using ::agent::GetResidualsRequest;
-using ::agent::GetResidualsResponse;
-using ::agent::GetCostValuesAndWeightsRequest;
-using ::agent::GetCostValuesAndWeightsResponse;
-using ::agent::GetModeRequest;
-using ::agent::GetModeResponse;
-using ::agent::GetStateResponse;
-using ::agent::GetTaskParametersRequest;
-using ::agent::GetTaskParametersResponse;
-using ::agent::Pose;
-using ::agent::SetAnythingRequest;
-using ::agent::SetAnythingResponse;
-using ::agent::SetCostWeightsRequest;
-using ::agent::SetModeRequest;
-using ::agent::SetStateRequest;
-using ::agent::SetTaskParametersRequest;
-using ::agent::Residual;
-using ::agent::ValueAndWeight;
+  using ::agent::GetActionRequest;
+  using ::agent::GetActionResponse;
+  using ::agent::GetAllModesRequest;
+  using ::agent::GetAllModesResponse;
+  using ::agent::GetCostValuesAndWeightsRequest;
+  using ::agent::GetCostValuesAndWeightsResponse;
+  using ::agent::GetModeRequest;
+  using ::agent::GetModeResponse;
+  using ::agent::GetResidualsRequest;
+  using ::agent::GetResidualsResponse;
+  using ::agent::GetSamplingPolicyParametersRequest;
+  using ::agent::GetSamplingPolicyParametersResponse;
+  using ::agent::GetStateResponse;
+  using ::agent::GetTaskParametersRequest;
+  using ::agent::GetTaskParametersResponse;
+  using ::agent::Pose;
+  using ::agent::Residual;
+  using ::agent::SetAnythingRequest;
+  using ::agent::SetAnythingResponse;
+  using ::agent::SetCostWeightsRequest;
+  using ::agent::SetModeRequest;
+  using ::agent::SetStateRequest;
+  using ::agent::SetTaskParametersRequest;
+  using ::agent::ValueAndWeight;
 
-grpc::Status GetState(const mjModel* model, const mjData* data,
-                      GetStateResponse* response) {
-  agent::State* output_state = response->mutable_state();
+  grpc::Status GetState(const mjModel *model, const mjData *data,
+                        GetStateResponse *response)
+  {
+    agent::State *output_state = response->mutable_state();
 
-  output_state->set_time(data->time);
-  for (int i = 0; i < model->nq; i++) {
-    output_state->add_qpos(data->qpos[i]);
-  }
-  for (int i = 0; i < model->nv; i++) {
-    output_state->add_qvel(data->qvel[i]);
-  }
-  for (int i = 0; i < model->na; i++) {
-    output_state->add_act(data->act[i]);
-  }
-  for (int i = 0; i < model->nmocap * 3; i++) {
-    output_state->add_mocap_pos(data->mocap_pos[i]);
-  }
-  for (int i = 0; i < model->nmocap * 4; i++) {
-    output_state->add_mocap_quat(data->mocap_quat[i]);
-  }
-  for (int i = 0; i < model->nuserdata; i++) {
-    output_state->add_userdata(data->userdata[i]);
-  }
+    output_state->set_time(data->time);
+    for (int i = 0; i < model->nq; i++)
+    {
+      output_state->add_qpos(data->qpos[i]);
+    }
+    for (int i = 0; i < model->nv; i++)
+    {
+      output_state->add_qvel(data->qvel[i]);
+    }
+    for (int i = 0; i < model->na; i++)
+    {
+      output_state->add_act(data->act[i]);
+    }
+    for (int i = 0; i < model->nmocap * 3; i++)
+    {
+      output_state->add_mocap_pos(data->mocap_pos[i]);
+    }
+    for (int i = 0; i < model->nmocap * 4; i++)
+    {
+      output_state->add_mocap_quat(data->mocap_quat[i]);
+    }
+    for (int i = 0; i < model->nuserdata; i++)
+    {
+      output_state->add_userdata(data->userdata[i]);
+    }
 
-  return grpc::Status::OK;
-}
-
-namespace {
-absl::Status CheckSize(std::string_view name, int model_size, int vector_size) {
-  std::ostringstream error_string;
-  if (model_size != vector_size) {
-    error_string << "expected " << name << " size " << model_size << ", got "
-                 << vector_size;
-    return absl::InvalidArgumentError(error_string.str());
-  }
-  return absl::OkStatus();
-}
-}  // namespace
-
-#define CHECK_SIZE(name, n1, n2) \
-{ \
-  auto expr = (CheckSize(name, n1, n2)); \
-if (!(expr).ok()) { \
-  return grpc::Status( \
-    grpc::StatusCode::INVALID_ARGUMENT, \
-    (expr).ToString()); \
-  } \
-}
-
-namespace {
-grpc::Status SetState(const agent::State& state, mjpc::Agent* agent,
-                      const mjModel* model, mjData* data) {
-  if (state.has_time()) data->time = state.time();
-
-  if (state.qpos_size() > 0) {
-    CHECK_SIZE("qpos", model->nq, state.qpos_size());
-    mju_copy(data->qpos, state.qpos().data(), model->nq);
+    return grpc::Status::OK;
   }
 
-  if (state.qvel_size() > 0) {
-    CHECK_SIZE("qvel", model->nv, state.qvel_size());
-    mju_copy(data->qvel, state.qvel().data(), model->nv);
+  namespace
+  {
+    absl::Status CheckSize(std::string_view name, int model_size, int vector_size)
+    {
+      std::ostringstream error_string;
+      if (model_size != vector_size)
+      {
+        error_string << "expected " << name << " size " << model_size << ", got "
+                     << vector_size;
+        return absl::InvalidArgumentError(error_string.str());
+      }
+      return absl::OkStatus();
+    }
+  } // namespace
+
+#define CHECK_SIZE(name, n1, n2)              \
+  {                                           \
+    auto expr = (CheckSize(name, n1, n2));    \
+    if (!(expr).ok())                         \
+    {                                         \
+      return grpc::Status(                    \
+          grpc::StatusCode::INVALID_ARGUMENT, \
+          (expr).ToString());                 \
+    }                                         \
   }
 
-  if (state.act_size() > 0) {
-    CHECK_SIZE("act", model->na, state.act_size());
-    mju_copy(data->act, state.act().data(), model->na);
+  namespace
+  {
+    grpc::Status SetState(const agent::State &state, mjpc::Agent *agent,
+                          const mjModel *model, mjData *data)
+    {
+      if (state.has_time())
+        data->time = state.time();
+
+      if (state.qpos_size() > 0)
+      {
+        CHECK_SIZE("qpos", model->nq, state.qpos_size());
+        mju_copy(data->qpos, state.qpos().data(), model->nq);
+      }
+
+      if (state.qvel_size() > 0)
+      {
+        CHECK_SIZE("qvel", model->nv, state.qvel_size());
+        mju_copy(data->qvel, state.qvel().data(), model->nv);
+      }
+
+      if (state.act_size() > 0)
+      {
+        CHECK_SIZE("act", model->na, state.act_size());
+        mju_copy(data->act, state.act().data(), model->na);
+      }
+
+      if (state.mocap_pos_size() > 0)
+      {
+        CHECK_SIZE("mocap_pos", model->nmocap * 3, state.mocap_pos_size());
+        mju_copy(data->mocap_pos, state.mocap_pos().data(), model->nmocap * 3);
+      }
+
+      if (state.mocap_quat_size() > 0)
+      {
+        CHECK_SIZE("mocap_quat", model->nmocap * 4, state.mocap_quat_size());
+        mju_copy(data->mocap_quat, state.mocap_quat().data(), model->nmocap * 4);
+      }
+
+      if (state.userdata_size() > 0)
+      {
+        CHECK_SIZE("userdata", model->nuserdata, state.userdata_size());
+        mju_copy(data->userdata, state.userdata().data(), model->nuserdata);
+      }
+
+      agent->SetState(data);
+
+      return grpc::Status::OK;
+    }
+  } // namespace
+
+  grpc::Status SetState(const SetStateRequest *request, mjpc::Agent *agent,
+                        const mjModel *model, mjData *data)
+  {
+    agent::State state = request->state();
+    return SetState(state, agent, model, data);
   }
-
-  if (state.mocap_pos_size() > 0) {
-    CHECK_SIZE("mocap_pos", model->nmocap * 3, state.mocap_pos_size());
-    mju_copy(data->mocap_pos, state.mocap_pos().data(), model->nmocap * 3);
-  }
-
-  if (state.mocap_quat_size() > 0) {
-    CHECK_SIZE("mocap_quat", model->nmocap * 4, state.mocap_quat_size());
-    mju_copy(data->mocap_quat, state.mocap_quat().data(), model->nmocap * 4);
-  }
-
-  if (state.userdata_size() > 0) {
-    CHECK_SIZE("userdata", model->nuserdata, state.userdata_size());
-    mju_copy(data->userdata, state.userdata().data(), model->nuserdata);
-  }
-
-  agent->SetState(data);
-
-  return grpc::Status::OK;
-}
-}  // namespace
-
-grpc::Status SetState(const SetStateRequest* request, mjpc::Agent* agent,
-                      const mjModel* model, mjData* data) {
-  agent::State state = request->state();
-  return SetState(state, agent, model, data);
-}
 
 #undef CHECK_SIZE
 
-namespace {
-// TODO(nimrod): make planner a const reference
-std::vector<double> AverageAction(mjpc::Planner& planner, const mjModel* model,
-                                  bool nominal_action, mjData* rollout_data,
-                                  mjpc::State* rollout_state, double time,
-                                  double averaging_duration) {
-  int nu = model->nu;
-  std::vector<double> ret(nu, 0);
-  int nactions = 0;
-  double end_time = time + averaging_duration;
+  namespace
+  {
+    // TODO(nimrod): make planner a const reference
+    std::vector<double> AverageAction(mjpc::Planner &planner, const mjModel *model,
+                                      bool nominal_action, mjData *rollout_data,
+                                      mjpc::State *rollout_state, double time,
+                                      double averaging_duration)
+    {
+      int nu = model->nu;
+      std::vector<double> ret(nu, 0);
+      int nactions = 0;
+      double end_time = time + averaging_duration;
 
-  if (nominal_action) {
-    std::vector<double> action(nu, 0);
-    while (time < end_time) {
-      planner.ActionFromPolicy(action.data(), /*state=*/nullptr, time);
-      mju_addTo(ret.data(), action.data(), nu);
-      time += model->opt.timestep;
-      nactions++;
+      if (nominal_action)
+      {
+        std::vector<double> action(nu, 0);
+        while (time < end_time)
+        {
+          planner.ActionFromPolicy(action.data(), /*state=*/nullptr, time);
+          mju_addTo(ret.data(), action.data(), nu);
+          time += model->opt.timestep;
+          nactions++;
+        }
+      }
+      else
+      {
+        rollout_data->time = time;
+        while (rollout_data->time <= end_time)
+        {
+          rollout_state->Set(model, rollout_data);
+          const double *state = rollout_state->state().data();
+          planner.ActionFromPolicy(rollout_data->ctrl, state,
+                                   rollout_data->time);
+          mju_addTo(ret.data(), rollout_data->ctrl, nu);
+          mj_step(model, rollout_data);
+          nactions++;
+        }
+      }
+      mju_scl(ret.data(), ret.data(), 1.0 / nactions, nu);
+      return ret;
     }
-  } else {
-    rollout_data->time = time;
-    while (rollout_data->time <= end_time) {
-      rollout_state->Set(model, rollout_data);
-      const double* state = rollout_state->state().data();
-      planner.ActionFromPolicy(rollout_data->ctrl, state,
-                                              rollout_data->time);
-      mju_addTo(ret.data(), rollout_data->ctrl, nu);
-      mj_step(model, rollout_data);
-      nactions++;
+
+  } // namespace
+  grpc::Status GetAction(const GetActionRequest *request,
+                         const mjpc::Agent *agent,
+                         const mjModel *model, mjData *rollout_data,
+                         mjpc::State *rollout_state,
+                         GetActionResponse *response)
+  {
+    double time =
+        request->has_time() ? request->time() : agent->state.time();
+
+    if (request->averaging_duration() > 0)
+    {
+      if (request->nominal_action())
+      {
+        rollout_data = nullptr;
+        rollout_state = nullptr;
+      }
+      else
+      {
+        agent->state.CopyTo(model, rollout_data);
+        rollout_state->Set(model, rollout_data);
+      }
+      std::vector<double> ret = AverageAction(agent->ActivePlanner(), model,
+                                              request->nominal_action(), rollout_data, rollout_state,
+                                              time, request->averaging_duration());
+      response->mutable_action()->Assign(ret.begin(), ret.end());
     }
-  }
-  mju_scl(ret.data(), ret.data(), 1.0 / nactions, nu);
-  return ret;
-}
-
-}  // namespace
-grpc::Status GetAction(const GetActionRequest* request,
-                       const mjpc::Agent* agent,
-                       const mjModel* model, mjData* rollout_data,
-                       mjpc::State* rollout_state,
-                       GetActionResponse* response) {
-  double time =
-      request->has_time() ? request->time() : agent->state.time();
-
-  if (request->averaging_duration() > 0) {
-    if (request->nominal_action()) {
-      rollout_data = nullptr;
-      rollout_state = nullptr;
-    } else {
-      agent->state.CopyTo(model, rollout_data);
-      rollout_state->Set(model, rollout_data);
+    else
+    {
+      std::vector<double> ret(model->nu, 0);
+      const double *state = request->nominal_action()
+                                ? nullptr
+                                : agent->state.state().data();
+      agent->ActivePlanner().ActionFromPolicy(ret.data(), state, time);
+      response->mutable_action()->Assign(ret.begin(), ret.end());
     }
-    std::vector<double> ret = AverageAction(agent->ActivePlanner(), model,
-                        request->nominal_action(), rollout_data, rollout_state,
-                        time, request->averaging_duration());
-    response->mutable_action()->Assign(ret.begin(), ret.end());
-  } else {
-    std::vector<double> ret(model->nu, 0);
-    const double* state = request->nominal_action()
-                              ? nullptr
-                              : agent->state.state().data();
-    agent->ActivePlanner().ActionFromPolicy(ret.data(), state, time);
-    response->mutable_action()->Assign(ret.begin(), ret.end());
+
+    return grpc::Status::OK;
   }
 
-  return grpc::Status::OK;
-}
+  grpc::Status GetSamplingPolicyParameters(const GetSamplingPolicyParametersRequest *request,
+                                           const mjpc::Agent *agent,
+                                           GetSamplingPolicyParametersResponse *response)
+  {
+    mjpc::Planner &planner = agent->ActivePlanner();
+    std::vector<double> parameters(planner.NumParameters(), 0);
+    planner.Parameters(parameters.data());
+    response->mutable_sampling_policy_parameters()->Assign(parameters.begin(), parameters.end());
 
-grpc::Status GetResiduals(
-    const GetResidualsRequest* request, const mjpc::Agent* agent,
-    const mjModel* model, mjData* data,
-    GetResidualsResponse* response) {
-  const mjModel* agent_model = agent->GetModel();
-  const mjpc::Task* task = agent->ActiveTask();
-  std::vector<double> residuals(task->num_residual, 0);  // scratch space
-  task->Residual(model, data, residuals.data());
-  std::vector<int> dim_norm_residual = task->dim_norm_residual;
-
-  int residual_shift = 0;
-  for (int i = 0; i < task->num_term; i++) {
-    CHECK_EQ(agent_model->sensor_type[i], mjSENS_USER);
-    std::string_view sensor_name(agent_model->names +
-                                  agent_model->name_sensoradr[i]);
-
-    std::vector<double> sensor_residual_values(
-        residuals.begin() + residual_shift,
-        residuals.begin() + residual_shift + dim_norm_residual[i]);
-    Residual sensor_residual;
-    sensor_residual.mutable_values()->Assign(sensor_residual_values.begin(),
-                                             sensor_residual_values.end());
-    (*response->mutable_values())[sensor_name] = sensor_residual;
-    residual_shift += dim_norm_residual[i];
+    return grpc::Status::OK;
   }
-  return grpc::Status::OK;
-}
 
-grpc::Status GetCostValuesAndWeights(
-    const GetCostValuesAndWeightsRequest* request, const mjpc::Agent* agent,
-    const mjModel* model, mjData* data,
-    GetCostValuesAndWeightsResponse* response) {
-  const mjModel* agent_model = agent->GetModel();
-  const mjpc::Task* task = agent->ActiveTask();
-  std::vector<double> residuals(task->num_residual, 0);  // scratch space
-  double terms[mjpc::kMaxCostTerms];
-  task->Residual(model, data, residuals.data());
-  task->UnweightedCostTerms(terms, residuals.data());
-  for (int i = 0; i < task->num_term; i++) {
-    CHECK_EQ(agent_model->sensor_type[i], mjSENS_USER);
-    std::string_view sensor_name(agent_model->names +
-                                  agent_model->name_sensoradr[i]);
-    ValueAndWeight value_and_weight;
-    value_and_weight.set_value(terms[i]);
-    value_and_weight.set_weight(task->weight[i]);
-    (*response->mutable_values_weights())[sensor_name] = value_and_weight;
+  grpc::Status GetResiduals(
+      const GetResidualsRequest *request, const mjpc::Agent *agent,
+      const mjModel *model, mjData *data,
+      GetResidualsResponse *response)
+  {
+    const mjModel *agent_model = agent->GetModel();
+    const mjpc::Task *task = agent->ActiveTask();
+    std::vector<double> residuals(task->num_residual, 0); // scratch space
+    task->Residual(model, data, residuals.data());
+    std::vector<int> dim_norm_residual = task->dim_norm_residual;
+
+    int residual_shift = 0;
+    for (int i = 0; i < task->num_term; i++)
+    {
+      CHECK_EQ(agent_model->sensor_type[i], mjSENS_USER);
+      std::string_view sensor_name(agent_model->names +
+                                   agent_model->name_sensoradr[i]);
+
+      std::vector<double> sensor_residual_values(
+          residuals.begin() + residual_shift,
+          residuals.begin() + residual_shift + dim_norm_residual[i]);
+      Residual sensor_residual;
+      sensor_residual.mutable_values()->Assign(sensor_residual_values.begin(),
+                                               sensor_residual_values.end());
+      (*response->mutable_values())[sensor_name] = sensor_residual;
+      residual_shift += dim_norm_residual[i];
+    }
+    return grpc::Status::OK;
   }
-  return grpc::Status::OK;
-}
 
-grpc::Status Reset(mjpc::Agent* agent, const mjModel* model, mjData* data) {
-  agent->Reset();
-  // TODO(nimrod): This should be in the agent, no?
-  int home_id = mj_name2id(model, mjOBJ_KEY, "home");
-  if (home_id >= 0) {
-    mj_resetDataKeyframe(model, data, home_id);
-  } else {
-    mj_resetData(model, data);
+  grpc::Status GetCostValuesAndWeights(
+      const GetCostValuesAndWeightsRequest *request, const mjpc::Agent *agent,
+      const mjModel *model, mjData *data,
+      GetCostValuesAndWeightsResponse *response)
+  {
+    const mjModel *agent_model = agent->GetModel();
+    const mjpc::Task *task = agent->ActiveTask();
+    std::vector<double> residuals(task->num_residual, 0); // scratch space
+    double terms[mjpc::kMaxCostTerms];
+    task->Residual(model, data, residuals.data());
+    task->UnweightedCostTerms(terms, residuals.data());
+    for (int i = 0; i < task->num_term; i++)
+    {
+      CHECK_EQ(agent_model->sensor_type[i], mjSENS_USER);
+      std::string_view sensor_name(agent_model->names +
+                                   agent_model->name_sensoradr[i]);
+      ValueAndWeight value_and_weight;
+      value_and_weight.set_value(terms[i]);
+      value_and_weight.set_weight(task->weight[i]);
+      (*response->mutable_values_weights())[sensor_name] = value_and_weight;
+    }
+    return grpc::Status::OK;
   }
-  agent->SetState(data);
-  return grpc::Status::OK;
-}
 
-grpc::Status SetTaskParameters(const SetTaskParametersRequest* request,
-                               mjpc::Agent* agent) {
-  for (const auto& [name, value] : request->parameters()) {
-    switch (value.value_case()) {
+  grpc::Status Reset(mjpc::Agent *agent, const mjModel *model, mjData *data)
+  {
+    agent->Reset();
+    // TODO(nimrod): This should be in the agent, no?
+    int home_id = mj_name2id(model, mjOBJ_KEY, "home");
+    if (home_id >= 0)
+    {
+      mj_resetDataKeyframe(model, data, home_id);
+    }
+    else
+    {
+      mj_resetData(model, data);
+    }
+    agent->SetState(data);
+    return grpc::Status::OK;
+  }
+
+  grpc::Status SetTaskParameters(const SetTaskParametersRequest *request,
+                                 mjpc::Agent *agent)
+  {
+    for (const auto &[name, value] : request->parameters())
+    {
+      switch (value.value_case())
+      {
       case agent::TaskParameterValue::kNumeric:
-        if (agent->SetParamByName(name, value.numeric()) == -1) {
+        if (agent->SetParamByName(name, value.numeric()) == -1)
+        {
           std::ostringstream error_string;
           error_string << "Parameter " << name
                        << " not found in task.  Available names are:\n";
-          auto* agent_model = agent->GetModel();
-          for (int i = 0; i < agent_model->nnumeric; i++) {
+          auto *agent_model = agent->GetModel();
+          for (int i = 0; i < agent_model->nnumeric; i++)
+          {
             std::string_view numeric_name(agent_model->names +
                                           agent_model->name_numericadr[i]);
             if (absl::StartsWith(numeric_name, "residual_") &&
-                !absl::StartsWith(numeric_name, "residual_select_")) {
+                !absl::StartsWith(numeric_name, "residual_select_"))
+            {
               error_string << absl::StripPrefix(numeric_name, "residual_")
                            << "\n";
             }
@@ -316,15 +382,18 @@ grpc::Status SetTaskParameters(const SetTaskParametersRequest* request,
         }
         break;
       case agent::TaskParameterValue::kSelection:
-        if (agent->SetSelectionParamByName(name, value.selection()) == -1) {
+        if (agent->SetSelectionParamByName(name, value.selection()) == -1)
+        {
           std::ostringstream error_string;
           error_string << "Parameter " << name
                        << " not found in task.  Available names are:\n";
           auto agent_model = agent->GetModel();
-          for (int i = 0; i < agent_model->nnumeric; i++) {
+          for (int i = 0; i < agent_model->nnumeric; i++)
+          {
             std::string_view numeric_name(agent_model->names +
                                           agent_model->name_numericadr[i]);
-            if (absl::StartsWith(numeric_name, "residual_select_")) {
+            if (absl::StartsWith(numeric_name, "residual_select_"))
+            {
               error_string << absl::StripPrefix(numeric_name,
                                                 "residual_select_")
                            << "\n";
@@ -337,233 +406,279 @@ grpc::Status SetTaskParameters(const SetTaskParametersRequest* request,
       default:
         return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
                             absl::StrCat("Missing value for parameter ", name));
-    }
-  }
-  agent->ActiveTask()->UpdateResidual();
-
-  return grpc::Status::OK;
-}
-
-grpc::Status GetTaskParameters(const GetTaskParametersRequest* request,
-                               mjpc::Agent* agent,
-                               GetTaskParametersResponse* response) {
-  mjModel* agent_model = agent->GetModel();
-  int shift = 0;
-  for (int i = 0; i < agent_model->nnumeric; i++) {
-    std::string_view numeric_name(agent_model->names +
-                                  agent_model->name_numericadr[i]);
-    if (absl::StartsWith(numeric_name, "residual_select_")) {
-      std::string_view name =
-          absl::StripPrefix(numeric_name, "residual_select_");
-      (*response->mutable_parameters())[name].set_selection(
-          mjpc::ResidualSelection(agent_model, name,
-                                  agent->ActiveTask()->parameters[shift]));
-      shift++;
-    } else if (absl::StartsWith(numeric_name, "residual_")) {
-      std::string_view name = absl::StripPrefix(numeric_name, "residual_");
-      (*response->mutable_parameters())[name].set_numeric(
-          agent->ActiveTask()->parameters[shift]);
-      shift++;
-    }
-  }
-
-  return grpc::Status::OK;
-}
-
-grpc::Status SetCostWeights(
-    const ::google::protobuf::Map<std::string, double>& cost_weights,
-    mjpc::Agent* agent) {
-  for (const auto& [name, weight] : cost_weights) {
-    if (agent->SetWeightByName(name, weight) == -1) {
-      std::ostringstream error_string;
-      error_string << "Weight '" << name
-                   << "' not found in task. Available names are:\n";
-      auto* agent_model = agent->GetModel();
-      for (int i = 0; i < agent_model->nsensor &&
-                      agent_model->sensor_type[i] == mjSENS_USER;
-           i++) {
-        std::string_view sensor_name(agent_model->names +
-                                     agent_model->name_sensoradr[i]);
-        error_string << "  " << sensor_name << "\n";
       }
-      return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                          error_string.str());
     }
-  }
-  return grpc::Status::OK;
-}
+    agent->ActiveTask()->UpdateResidual();
 
-grpc::Status SetCostWeights(const SetCostWeightsRequest* request,
-                            mjpc::Agent* agent) {
-  if (request->reset_to_defaults()) {
-    agent->ActiveTask()->Reset(agent->GetModel());
-  }
-  auto cost_weights = request->cost_weights();
-  return SetCostWeights(cost_weights, agent);
-}
-
-
-grpc::Status SetMode(std::string_view mode, mjpc::Agent* agent) {
-  int outcome = agent->SetModeByName(mode);
-  if (outcome == -1) {
-    std::vector<std::string> mode_names = agent->GetAllModeNames();
-    std::ostringstream error_string;
-    error_string << "Mode '" << mode
-                  << "' not found in task. Available names are:\n";
-    for (const auto& mode_name : mode_names) {
-      error_string << "  " << mode_name << "\n";
-    }
-    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, error_string.str());
-  } else {
     return grpc::Status::OK;
   }
-}
 
-grpc::Status SetMode(const SetModeRequest* request, mjpc::Agent* agent) {
-  return SetMode(request->mode(), agent);
-}
-
-grpc::Status GetMode(const GetModeRequest* request, mjpc::Agent* agent,
-                     GetModeResponse* response) {
-  response->set_mode(agent->GetModeName());
-  return grpc::Status::OK;
-}
-
-grpc::Status GetAllModes(const GetAllModesRequest* request, mjpc::Agent* agent,
-                         GetAllModesResponse* response) {
-  std::vector<std::string> mode_names = agent->GetAllModeNames();
-  for (const auto& mode_name : mode_names) {
-    response->add_mode_names(mode_name);
-  }
-  return grpc::Status::OK;
-}
-
-namespace {
-grpc::Status SetMocap(const ::google::protobuf::Map<std::string, Pose>& mocap,
-                      mjpc::Agent* agent, const mjModel* model, mjData* data) {
-  // Check all names and poses before applying changes.
-  for (const auto& [name, pose] : mocap) {
-    int id = mj_name2id(model, mjOBJ_BODY, name.c_str());
-    if (id < 0) {
-      return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                          absl::StrFormat("Body '%s' not found.", name));
-    }
-    int mocap_id = model->body_mocapid[id];
-    if (mocap_id < 0) {
-      return grpc::Status(
-          grpc::StatusCode::INVALID_ARGUMENT,
-          absl::StrFormat("Body '%s' is not a mocap body.", name));
-    }
-    if (pose.pos_size() != 0 && pose.pos_size() != 3) {
-      return grpc::Status(
-          grpc::StatusCode::INVALID_ARGUMENT,
-          absl::StrFormat("Mocap '%s' has invalid pose size %d.", name,
-                          pose.pos_size()));
-    }
-    if (pose.quat_size() != 0 && pose.quat_size() != 4) {
-      return grpc::Status(
-          grpc::StatusCode::INVALID_ARGUMENT,
-          absl::StrFormat("Mocap '%s' has invalid quat size %d.", name,
-                          pose.pos_size()));
-    }
-  }
-  for (const auto& [name, pose] : mocap) {
-    int id = mj_name2id(model, mjOBJ_BODY, name.c_str());
-    int mocap_id = model->body_mocapid[id];
-    for (int i = 0; i < pose.pos_size(); i++) {
-      data->mocap_pos[3*mocap_id + i] = pose.pos(i);
-    }
-    if (pose.quat_size() == 4) {
-      for (int i = 0; i < 4; i++) {
-        data->mocap_quat[4*mocap_id + i] = pose.quat(i);
+  grpc::Status GetTaskParameters(const GetTaskParametersRequest *request,
+                                 mjpc::Agent *agent,
+                                 GetTaskParametersResponse *response)
+  {
+    mjModel *agent_model = agent->GetModel();
+    int shift = 0;
+    for (int i = 0; i < agent_model->nnumeric; i++)
+    {
+      std::string_view numeric_name(agent_model->names +
+                                    agent_model->name_numericadr[i]);
+      if (absl::StartsWith(numeric_name, "residual_select_"))
+      {
+        std::string_view name =
+            absl::StripPrefix(numeric_name, "residual_select_");
+        (*response->mutable_parameters())[name].set_selection(
+            mjpc::ResidualSelection(agent_model, name,
+                                    agent->ActiveTask()->parameters[shift]));
+        shift++;
       }
-      mju_normalize4(data->mocap_quat + 4*mocap_id);
+      else if (absl::StartsWith(numeric_name, "residual_"))
+      {
+        std::string_view name = absl::StripPrefix(numeric_name, "residual_");
+        (*response->mutable_parameters())[name].set_numeric(
+            agent->ActiveTask()->parameters[shift]);
+        shift++;
+      }
+    }
+
+    return grpc::Status::OK;
+  }
+
+  grpc::Status SetCostWeights(
+      const ::google::protobuf::Map<std::string, double> &cost_weights,
+      mjpc::Agent *agent)
+  {
+    for (const auto &[name, weight] : cost_weights)
+    {
+      if (agent->SetWeightByName(name, weight) == -1)
+      {
+        std::ostringstream error_string;
+        error_string << "Weight '" << name
+                     << "' not found in task. Available names are:\n";
+        auto *agent_model = agent->GetModel();
+        for (int i = 0; i < agent_model->nsensor &&
+                        agent_model->sensor_type[i] == mjSENS_USER;
+             i++)
+        {
+          std::string_view sensor_name(agent_model->names +
+                                       agent_model->name_sensoradr[i]);
+          error_string << "  " << sensor_name << "\n";
+        }
+        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                            error_string.str());
+      }
+    }
+    return grpc::Status::OK;
+  }
+
+  grpc::Status SetCostWeights(const SetCostWeightsRequest *request,
+                              mjpc::Agent *agent)
+  {
+    if (request->reset_to_defaults())
+    {
+      agent->ActiveTask()->Reset(agent->GetModel());
+    }
+    auto cost_weights = request->cost_weights();
+    return SetCostWeights(cost_weights, agent);
+  }
+
+  grpc::Status SetMode(std::string_view mode, mjpc::Agent *agent)
+  {
+    int outcome = agent->SetModeByName(mode);
+    if (outcome == -1)
+    {
+      std::vector<std::string> mode_names = agent->GetAllModeNames();
+      std::ostringstream error_string;
+      error_string << "Mode '" << mode
+                   << "' not found in task. Available names are:\n";
+      for (const auto &mode_name : mode_names)
+      {
+        error_string << "  " << mode_name << "\n";
+      }
+      return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, error_string.str());
+    }
+    else
+    {
+      return grpc::Status::OK;
     }
   }
-  agent->SetState(data);
-  return grpc::Status::OK;
-}
-}  // namespace
 
-grpc::Status SetAnything(const SetAnythingRequest* request, mjpc::Agent* agent,
-                         const mjModel* model, mjData* data,
-                         SetAnythingResponse* response) {
-  if (request->has_state()) {
-    grpc::Status status = SetState(request->state(), agent, model, data);
-    if (!status.ok()) {
-      return status;
+  grpc::Status SetMode(const SetModeRequest *request, mjpc::Agent *agent)
+  {
+    return SetMode(request->mode(), agent);
+  }
+
+  grpc::Status GetMode(const GetModeRequest *request, mjpc::Agent *agent,
+                       GetModeResponse *response)
+  {
+    response->set_mode(agent->GetModeName());
+    return grpc::Status::OK;
+  }
+
+  grpc::Status GetAllModes(const GetAllModesRequest *request, mjpc::Agent *agent,
+                           GetAllModesResponse *response)
+  {
+    std::vector<std::string> mode_names = agent->GetAllModeNames();
+    for (const auto &mode_name : mode_names)
+    {
+      response->add_mode_names(mode_name);
     }
+    return grpc::Status::OK;
   }
-  if (request->cost_weights_size() > 0) {
-    grpc::Status status = SetCostWeights(request->cost_weights(), agent);
-    if (!status.ok()) {
-      return status;
+
+  namespace
+  {
+    grpc::Status SetMocap(const ::google::protobuf::Map<std::string, Pose> &mocap,
+                          mjpc::Agent *agent, const mjModel *model, mjData *data)
+    {
+      // Check all names and poses before applying changes.
+      for (const auto &[name, pose] : mocap)
+      {
+        int id = mj_name2id(model, mjOBJ_BODY, name.c_str());
+        if (id < 0)
+        {
+          return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                              absl::StrFormat("Body '%s' not found.", name));
+        }
+        int mocap_id = model->body_mocapid[id];
+        if (mocap_id < 0)
+        {
+          return grpc::Status(
+              grpc::StatusCode::INVALID_ARGUMENT,
+              absl::StrFormat("Body '%s' is not a mocap body.", name));
+        }
+        if (pose.pos_size() != 0 && pose.pos_size() != 3)
+        {
+          return grpc::Status(
+              grpc::StatusCode::INVALID_ARGUMENT,
+              absl::StrFormat("Mocap '%s' has invalid pose size %d.", name,
+                              pose.pos_size()));
+        }
+        if (pose.quat_size() != 0 && pose.quat_size() != 4)
+        {
+          return grpc::Status(
+              grpc::StatusCode::INVALID_ARGUMENT,
+              absl::StrFormat("Mocap '%s' has invalid quat size %d.", name,
+                              pose.pos_size()));
+        }
+      }
+      for (const auto &[name, pose] : mocap)
+      {
+        int id = mj_name2id(model, mjOBJ_BODY, name.c_str());
+        int mocap_id = model->body_mocapid[id];
+        for (int i = 0; i < pose.pos_size(); i++)
+        {
+          data->mocap_pos[3 * mocap_id + i] = pose.pos(i);
+        }
+        if (pose.quat_size() == 4)
+        {
+          for (int i = 0; i < 4; i++)
+          {
+            data->mocap_quat[4 * mocap_id + i] = pose.quat(i);
+          }
+          mju_normalize4(data->mocap_quat + 4 * mocap_id);
+        }
+      }
+      agent->SetState(data);
+      return grpc::Status::OK;
     }
-  }
-  if (!request->mode().empty()) {
-    grpc::Status status = SetMode(request->mode(), agent);
-    if (!status.ok()) {
-      return status;
+  } // namespace
+
+  grpc::Status SetAnything(const SetAnythingRequest *request, mjpc::Agent *agent,
+                           const mjModel *model, mjData *data,
+                           SetAnythingResponse *response)
+  {
+    if (request->has_state())
+    {
+      grpc::Status status = SetState(request->state(), agent, model, data);
+      if (!status.ok())
+      {
+        return status;
+      }
     }
-  }
-  if (request->mocap_size() > 0) {
-    grpc::Status status = SetMocap(request->mocap(), agent, model, data);
-    if (!status.ok()) {
-      return status;
+    if (request->cost_weights_size() > 0)
+    {
+      grpc::Status status = SetCostWeights(request->cost_weights(), agent);
+      if (!status.ok())
+      {
+        return status;
+      }
     }
+    if (!request->mode().empty())
+    {
+      grpc::Status status = SetMode(request->mode(), agent);
+      if (!status.ok())
+      {
+        return status;
+      }
+    }
+    if (request->mocap_size() > 0)
+    {
+      grpc::Status status = SetMocap(request->mocap(), agent, model, data);
+      if (!status.ok())
+      {
+        return status;
+      }
+    }
+    return grpc::Status::OK;
   }
-  return grpc::Status::OK;
-}
 
-mjpc::UniqueMjModel LoadModelFromString(std::string_view xml, char* error,
-                             int error_size) {
-  static constexpr char file[] = "temporary-filename.xml";
-  // mjVFS structs need to be allocated on the heap, because it's ~2MB
-  auto vfs = std::make_unique<mjVFS>();
-  mj_defaultVFS(vfs.get());
-  mj_makeEmptyFileVFS(vfs.get(), file, xml.size());
-  int file_idx = mj_findFileVFS(vfs.get(), file);
-  std::memcpy(vfs->filedata[file_idx], xml.data(), xml.size());
-  mjpc::UniqueMjModel m = {mj_loadXML(file, vfs.get(), error, error_size),
-                           mj_deleteModel};
-  mj_deleteFileVFS(vfs.get(), file);
-  return m;
-}
-
-mjpc::UniqueMjModel LoadModelFromBytes(std::string_view mjb) {
-  static constexpr char file[] = "temporary-filename.mjb";
-  // mjVFS structs need to be allocated on the heap, because it's ~2MB
-  auto vfs = std::make_unique<mjVFS>();
-  mj_defaultVFS(vfs.get());
-  mj_makeEmptyFileVFS(vfs.get(), file, mjb.size());
-  int file_idx = mj_findFileVFS(vfs.get(), file);
-  memcpy(vfs->filedata[file_idx], mjb.data(), mjb.size());
-  mjpc::UniqueMjModel m = {mj_loadModel(file, vfs.get()), mj_deleteModel};
-  mj_deleteFileVFS(vfs.get(), file);
-  return m;
-}
-
-grpc::Status InitAgent(mjpc::Agent* agent, const agent::InitRequest* request) {
-  std::string_view task_id = request->task_id();
-  int task_index = agent->GetTaskIdByName(task_id);
-  if (task_index == -1) {
-    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
-                        absl::StrFormat("Invalid task_id: '%s'", task_id));
+  mjpc::UniqueMjModel LoadModelFromString(std::string_view xml, char *error,
+                                          int error_size)
+  {
+    static constexpr char file[] = "temporary-filename.xml";
+    // mjVFS structs need to be allocated on the heap, because it's ~2MB
+    auto vfs = std::make_unique<mjVFS>();
+    mj_defaultVFS(vfs.get());
+    mj_makeEmptyFileVFS(vfs.get(), file, xml.size());
+    int file_idx = mj_findFileVFS(vfs.get(), file);
+    std::memcpy(vfs->filedata[file_idx], xml.data(), xml.size());
+    mjpc::UniqueMjModel m = {mj_loadXML(file, vfs.get(), error, error_size),
+                             mj_deleteModel};
+    mj_deleteFileVFS(vfs.get(), file);
+    return m;
   }
-  agent->gui_task_id = task_index;
 
-  mjpc::UniqueMjModel tmp_model = {nullptr, mj_deleteModel};
-  char load_error[1024] = "";
-
-  if (request->has_model() && request->model().has_mjb()) {
-    std::string_view model_mjb_bytes = request->model().mjb();
-    // TODO(khartikainen): Add error handling for mjb loading.
-    tmp_model = LoadModelFromBytes(model_mjb_bytes);
-  } else if (request->has_model() && request->model().has_xml()) {
-    std::string_view model_xml = request->model().xml();
-    tmp_model = LoadModelFromString(model_xml, load_error, sizeof(load_error));
+  mjpc::UniqueMjModel LoadModelFromBytes(std::string_view mjb)
+  {
+    static constexpr char file[] = "temporary-filename.mjb";
+    // mjVFS structs need to be allocated on the heap, because it's ~2MB
+    auto vfs = std::make_unique<mjVFS>();
+    mj_defaultVFS(vfs.get());
+    mj_makeEmptyFileVFS(vfs.get(), file, mjb.size());
+    int file_idx = mj_findFileVFS(vfs.get(), file);
+    memcpy(vfs->filedata[file_idx], mjb.data(), mjb.size());
+    mjpc::UniqueMjModel m = {mj_loadModel(file, vfs.get()), mj_deleteModel};
+    mj_deleteFileVFS(vfs.get(), file);
+    return m;
   }
-  agent->OverrideModel(std::move(tmp_model));
-  return grpc::Status::OK;
-}
-}  // namespace grpc_agent_util
+
+  grpc::Status InitAgent(mjpc::Agent *agent, const agent::InitRequest *request)
+  {
+    std::string_view task_id = request->task_id();
+    int task_index = agent->GetTaskIdByName(task_id);
+    if (task_index == -1)
+    {
+      return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT,
+                          absl::StrFormat("Invalid task_id: '%s'", task_id));
+    }
+    agent->gui_task_id = task_index;
+
+    mjpc::UniqueMjModel tmp_model = {nullptr, mj_deleteModel};
+    char load_error[1024] = "";
+
+    if (request->has_model() && request->model().has_mjb())
+    {
+      std::string_view model_mjb_bytes = request->model().mjb();
+      // TODO(khartikainen): Add error handling for mjb loading.
+      tmp_model = LoadModelFromBytes(model_mjb_bytes);
+    }
+    else if (request->has_model() && request->model().has_xml())
+    {
+      std::string_view model_xml = request->model().xml();
+      tmp_model = LoadModelFromString(model_xml, load_error, sizeof(load_error));
+    }
+    agent->OverrideModel(std::move(tmp_model));
+    return grpc::Status::OK;
+  }
+} // namespace grpc_agent_util

--- a/mjpc/grpc/grpc_agent_util.h
+++ b/mjpc/grpc/grpc_agent_util.h
@@ -34,6 +34,9 @@ grpc::Status GetAction(const agent::GetActionRequest* request,
                        const mjModel* model, mjData* rollout_data,
                        mjpc::State* rollout_state,
                        agent::GetActionResponse* response);
+grpc::Status GetSamplingPolicyParameters(const agent::GetSamplingPolicyParametersRequest* request,
+                                 const mjpc::Agent* agent,
+                                 agent::GetSamplingPolicyParametersResponse* response);
 grpc::Status GetResiduals(
     const agent::GetResidualsRequest* request,
     const mjpc::Agent* agent, const mjModel* model, mjData* data,

--- a/mjpc/grpc/grpc_agent_util.h
+++ b/mjpc/grpc/grpc_agent_util.h
@@ -24,53 +24,54 @@
 #include "mjpc/states/state.h"
 #include "mjpc/utilities.h"
 
-namespace grpc_agent_util {
-grpc::Status GetState(const mjModel* model, const mjData* data,
-                      agent::GetStateResponse* response);
-grpc::Status SetState(const agent::SetStateRequest* request, mjpc::Agent* agent,
-                      const mjModel* model, mjData* data);
-grpc::Status GetAction(const agent::GetActionRequest* request,
-                       const mjpc::Agent* agent,
-                       const mjModel* model, mjData* rollout_data,
-                       mjpc::State* rollout_state,
-                       agent::GetActionResponse* response);
-grpc::Status GetSamplingPolicyParameters(const agent::GetSamplingPolicyParametersRequest* request,
-                                 const mjpc::Agent* agent,
-                                 agent::GetSamplingPolicyParametersResponse* response);
-grpc::Status GetResiduals(
-    const agent::GetResidualsRequest* request,
-    const mjpc::Agent* agent, const mjModel* model, mjData* data,
-    agent::GetResidualsResponse* response);
-grpc::Status GetCostValuesAndWeights(
-    const agent::GetCostValuesAndWeightsRequest* request,
-    const mjpc::Agent* agent, const mjModel* model, mjData* data,
-    agent::GetCostValuesAndWeightsResponse* response);
-grpc::Status Reset(mjpc::Agent* agent, const mjModel* model, mjData* data);
-grpc::Status SetTaskParameters(const agent::SetTaskParametersRequest* request,
-                               mjpc::Agent* agent);
-grpc::Status GetTaskParameters(const agent::GetTaskParametersRequest* request,
-                               mjpc::Agent* agent,
-                              agent::GetTaskParametersResponse* response);
-grpc::Status SetCostWeights(const agent::SetCostWeightsRequest* request,
-                            mjpc::Agent* agent);
-grpc::Status SetMode(const agent::SetModeRequest* request, mjpc::Agent* agent);
-grpc::Status GetMode(const agent::GetModeRequest* request, mjpc::Agent* agent,
-                     agent::GetModeResponse* response);
+namespace grpc_agent_util
+{
+    grpc::Status GetState(const mjModel *model, const mjData *data,
+                          agent::GetStateResponse *response);
+    grpc::Status SetState(const agent::SetStateRequest *request, mjpc::Agent *agent,
+                          const mjModel *model, mjData *data);
+    grpc::Status GetAction(const agent::GetActionRequest *request,
+                           const mjpc::Agent *agent,
+                           const mjModel *model, mjData *rollout_data,
+                           mjpc::State *rollout_state,
+                           agent::GetActionResponse *response);
+    grpc::Status GetPolicyParameters(const agent::GetPolicyParametersRequest *request,
+                                     const mjpc::Agent *agent,
+                                     agent::GetPolicyParametersResponse *response);
+    grpc::Status GetResiduals(
+        const agent::GetResidualsRequest *request,
+        const mjpc::Agent *agent, const mjModel *model, mjData *data,
+        agent::GetResidualsResponse *response);
+    grpc::Status GetCostValuesAndWeights(
+        const agent::GetCostValuesAndWeightsRequest *request,
+        const mjpc::Agent *agent, const mjModel *model, mjData *data,
+        agent::GetCostValuesAndWeightsResponse *response);
+    grpc::Status Reset(mjpc::Agent *agent, const mjModel *model, mjData *data);
+    grpc::Status SetTaskParameters(const agent::SetTaskParametersRequest *request,
+                                   mjpc::Agent *agent);
+    grpc::Status GetTaskParameters(const agent::GetTaskParametersRequest *request,
+                                   mjpc::Agent *agent,
+                                   agent::GetTaskParametersResponse *response);
+    grpc::Status SetCostWeights(const agent::SetCostWeightsRequest *request,
+                                mjpc::Agent *agent);
+    grpc::Status SetMode(const agent::SetModeRequest *request, mjpc::Agent *agent);
+    grpc::Status GetMode(const agent::GetModeRequest *request, mjpc::Agent *agent,
+                         agent::GetModeResponse *response);
 
-grpc::Status GetAllModes(const agent::GetAllModesRequest* request,
-                         mjpc::Agent* agent,
-                         agent::GetAllModesResponse* response);
-grpc::Status SetAnything(const agent::SetAnythingRequest* request,
-                         mjpc::Agent* agent, const mjModel* model, mjData* data,
-                         agent::SetAnythingResponse* response);
+    grpc::Status GetAllModes(const agent::GetAllModesRequest *request,
+                             mjpc::Agent *agent,
+                             agent::GetAllModesResponse *response);
+    grpc::Status SetAnything(const agent::SetAnythingRequest *request,
+                             mjpc::Agent *agent, const mjModel *model, mjData *data,
+                             agent::SetAnythingResponse *response);
 
-mjpc::UniqueMjModel LoadModelFromString(std::string_view xml, char* error,
-                             int error_size);
-mjpc::UniqueMjModel LoadModelFromBytes(std::string_view mjb);
+    mjpc::UniqueMjModel LoadModelFromString(std::string_view xml, char *error,
+                                            int error_size);
+    mjpc::UniqueMjModel LoadModelFromBytes(std::string_view mjb);
 
-// set up the task and model on the agent so that the next call to
-// agent.LoadModel returns any custom model, or the relevant task model.
-grpc::Status InitAgent(mjpc::Agent* agent, const agent::InitRequest* request);
-}  // namespace grpc_agent_util
+    // set up the task and model on the agent so that the next call to
+    // agent.LoadModel returns any custom model, or the relevant task model.
+    grpc::Status InitAgent(mjpc::Agent *agent, const agent::InitRequest *request);
+} // namespace grpc_agent_util
 
-#endif  // MJPC_MJPC_GRPC_GRPC_AGENT_UTIL_H_
+#endif // MJPC_MJPC_GRPC_GRPC_AGENT_UTIL_H_

--- a/mjpc/planners/cross_entropy/planner.cc
+++ b/mjpc/planners/cross_entropy/planner.cc
@@ -32,369 +32,411 @@
 #include "mjpc/trajectory.h"
 #include "mjpc/utilities.h"
 
-namespace mjpc {
+namespace mjpc
+{
 
-namespace mju = ::mujoco::util_mjpc;
-using mjpc::spline::SplineInterpolation;
-using mjpc::spline::TimeSpline;
+  namespace mju = ::mujoco::util_mjpc;
+  using mjpc::spline::SplineInterpolation;
+  using mjpc::spline::TimeSpline;
 
-// initialize data and settings
-void CrossEntropyPlanner::Initialize(mjModel* model, const Task& task) {
-  // delete mjData instances since model might have changed.
-  data_.clear();
-
-  // allocate one mjData for nominal.
-  ResizeMjData(model, 1);
-
-  // model
-  this->model = model;
-
-  // task
-  this->task = &task;
-
-  // sampling noise
-  std_initial_ =
-      GetNumberOrDefault(0.1, model,
-                         "sampling_exploration");        // initial variance
-  std_min_ = GetNumberOrDefault(0.1, model, "std_min");  // minimum variance
-
-  // set number of trajectories to rollout
-  num_trajectory_ = GetNumberOrDefault(10, model, "sampling_trajectories");
-  interpolation_ = GetNumberOrDefault(SplineInterpolation::kCubicSpline, model,
-                                      "sampling_representation");
-
-  // set number of elite samples max(best 10%, 2)
-  n_elite_ =
-      GetNumberOrDefault(std::max(num_trajectory_ / 10, 2), model, "n_elite");
-
-  if (num_trajectory_ > kMaxTrajectory) {
-    mju_error_i("Too many trajectories, %d is the maximum allowed.",
-                kMaxTrajectory);
-  }
-}
-
-// allocate memory
-void CrossEntropyPlanner::Allocate() {
-  // initial state
-  int num_state = model->nq + model->nv + model->na;
-
-  // state
-  state.resize(num_state);
-  mocap.resize(7 * model->nmocap);
-  userdata.resize(model->nuserdata);
-
-  // policy
-  int num_max_parameter = model->nu * kMaxTrajectoryHorizon;
-  policy.Allocate(model, *task, kMaxTrajectoryHorizon);
-  resampled_policy.Allocate(model, *task, kMaxTrajectoryHorizon);
-  previous_policy.Allocate(model, *task, kMaxTrajectoryHorizon);
-
-  // scratch
-  parameters_scratch.resize(num_max_parameter);
-  times_scratch.resize(kMaxTrajectoryHorizon);
-
-  // noise
-  noise.resize(kMaxTrajectory * (model->nu * kMaxTrajectoryHorizon));
-
-  // variance
-  variance.resize(model->nu * kMaxTrajectoryHorizon);  // (nu * horizon)
-
-  // need to initialize an arbitrary order of the trajectories
-  trajectory_order.resize(kMaxTrajectory);
-  for (int i = 0; i < kMaxTrajectory; i++) {
-    trajectory_order[i] = i;
-  }
-
-  // trajectories and parameters
-  for (int i = 0; i < kMaxTrajectory; i++) {
-    trajectory[i].Initialize(num_state, model->nu, task->num_residual,
-                             task->num_trace, kMaxTrajectoryHorizon);
-    trajectory[i].Allocate(kMaxTrajectoryHorizon);
-    candidate_policy[i].Allocate(model, *task, kMaxTrajectoryHorizon);
-  }
-  nominal_trajectory.Initialize(num_state, model->nu, task->num_residual,
-                                task->num_trace, kMaxTrajectoryHorizon);
-  nominal_trajectory.Allocate(kMaxTrajectoryHorizon);
-}
-
-// reset memory to zeros
-void CrossEntropyPlanner::Reset(int horizon,
-                                const double* initial_repeated_action) {
-  // state
-  std::fill(state.begin(), state.end(), 0.0);
-  std::fill(mocap.begin(), mocap.end(), 0.0);
-  std::fill(userdata.begin(), userdata.end(), 0.0);
-  time = 0.0;
-
-  // policy parameters
-  policy.Reset(horizon, initial_repeated_action);
-  resampled_policy.Reset(horizon, initial_repeated_action);
-  previous_policy.Reset(horizon, initial_repeated_action);
-
-  // scratch
-  std::fill(parameters_scratch.begin(), parameters_scratch.end(), 0.0);
-  std::fill(times_scratch.begin(), times_scratch.end(), 0.0);
-
-  // noise
-  std::fill(noise.begin(), noise.end(), 0.0);
-
-  // variance
-  double var = std_initial_ * std_initial_;
-  std::fill(variance.begin(), variance.end(), var);
-
-  // trajectory samples
-  for (int i = 0; i < kMaxTrajectory; i++) {
-    trajectory[i].Reset(kMaxTrajectoryHorizon);
-    candidate_policy[i].Reset(horizon);
-  }
-  nominal_trajectory.Reset(kMaxTrajectoryHorizon);
-
-  for (const auto& d : data_) {
-    mju_zero(d->ctrl, model->nu);
-  }
-
-  // improvement
-  improvement = 0.0;
-}
-
-// set state
-void CrossEntropyPlanner::SetState(const State& state) {
-  state.CopyTo(this->state.data(), this->mocap.data(), this->userdata.data(),
-               &this->time);
-}
-
-// optimize nominal policy using random sampling
-void CrossEntropyPlanner::OptimizePolicy(int horizon, ThreadPool& pool) {
-  resampled_policy.plan.SetInterpolation(interpolation_);
-
-  // if num_trajectory_ has changed, use it in this new iteration.
-  // num_trajectory_ might change while this function runs. Keep it constant
-  // for the duration of this function.
-  int num_trajectory = num_trajectory_;
-
-  // n_elite_ might change in the GUI - keep constant for in this function
-  n_elite_ = std::min(n_elite_, num_trajectory);
-  int n_elite = std::min(n_elite_, num_trajectory);
-
-  // resize number of mjData
-  ResizeMjData(model, pool.NumThreads());
-
-  // copy nominal policy
+  // initialize data and settings
+  void CrossEntropyPlanner::Initialize(mjModel *model, const Task &task)
   {
-    const std::shared_lock<std::shared_mutex> lock(mtx_);
-    resampled_policy.CopyFrom(policy, policy.num_spline_points);
-  }
+    // delete mjData instances since model might have changed.
+    data_.clear();
 
-  // resample nominal policy to current time
-  this->ResamplePolicy(horizon);
+    // allocate one mjData for nominal.
+    ResizeMjData(model, 1);
 
-  // ----- rollout noisy policies ----- //
-  // start timer
-  auto rollouts_start = std::chrono::steady_clock::now();
+    // model
+    this->model = model;
 
-  // simulate noisy policies
-  this->Rollouts(num_trajectory, horizon, pool);
+    // task
+    this->task = &task;
 
-  // sort candidate policies and trajectories by score
-  for (int i = 0; i < num_trajectory; i++) {
-    trajectory_order[i] = i;
-  }
+    // sampling noise
+    std_initial_ =
+        GetNumberOrDefault(0.1, model,
+                           "sampling_exploration");       // initial variance
+    std_min_ = GetNumberOrDefault(0.1, model, "std_min"); // minimum variance
 
-  // sort so that the first ncandidates elements are the best candidates, and
-  // the rest are in an unspecified order
-  std::partial_sort(
-      trajectory_order.begin(), trajectory_order.begin() + num_trajectory,
-      trajectory_order.begin() + num_trajectory,
-      [&trajectory = trajectory](int a, int b) {
-        return trajectory[a].total_return < trajectory[b].total_return;
-      });
+    // set number of trajectories to rollout
+    num_trajectory_ = GetNumberOrDefault(10, model, "sampling_trajectories");
+    interpolation_ = GetNumberOrDefault(SplineInterpolation::kCubicSpline, model,
+                                        "sampling_representation");
 
-  // stop timer
-  rollouts_compute_time = GetDuration(rollouts_start);
+    // set number of elite samples max(best 10%, 2)
+    n_elite_ =
+        GetNumberOrDefault(std::max(num_trajectory_ / 10, 2), model, "n_elite");
 
-  // ----- update policy ----- //
-  // start timer
-  auto policy_update_start = std::chrono::steady_clock::now();
-
-  // dimensions
-  int num_spline_points = resampled_policy.num_spline_points;
-  int num_parameters = num_spline_points * model->nu;
-
-  // averaged return over elites
-  double avg_return = 0.0;
-
-  // reset parameters scratch
-  std::fill(parameters_scratch.begin(), parameters_scratch.end(), 0.0);
-
-  // loop over elites to compute average
-  for (int i = 0; i < n_elite; i++) {
-    // ordered trajectory index
-    int idx = trajectory_order[i];
-
-    // add parameters
-    for (int i = 0; i < num_spline_points; i++) {
-      TimeSpline::Node n = candidate_policy[idx].plan.NodeAt(i);
-      for (int j = 0; j < model->nu; j++) {
-        parameters_scratch[i * model->nu + j] += n.values()[j];
-      }
-    }
-
-    // add total return
-    avg_return += trajectory[idx].total_return;
-  }
-
-  // normalize
-  mju_scl(parameters_scratch.data(), parameters_scratch.data(), 1.0 / n_elite,
-          num_parameters);
-  avg_return /= n_elite;
-
-  // loop over elites to compute variance
-  std::fill(variance.begin(), variance.end(), 0.0);  // reset variance to zero
-  for (int t = 0; t < num_spline_points; t++) {
-    TimeSpline::Node n = candidate_policy[trajectory_order[0]].plan.NodeAt(t);
-    for (int j = 0; j < model->nu; j++) {
-      // average
-      double p_avg = parameters_scratch[t * model->nu + j];
-      for (int i = 0; i < n_elite; i++) {
-        // candidate parameter
-        double pi = n.values()[j];
-        double diff = pi - p_avg;
-        variance[t * model->nu + j] += diff * diff / (n_elite - 1);
-      }
+    if (num_trajectory_ > kMaxTrajectory)
+    {
+      mju_error_i("Too many trajectories, %d is the maximum allowed.",
+                  kMaxTrajectory);
     }
   }
 
-  // update
+  // allocate memory
+  void CrossEntropyPlanner::Allocate()
+  {
+    // initial state
+    int num_state = model->nq + model->nv + model->na;
+
+    // state
+    state.resize(num_state);
+    mocap.resize(7 * model->nmocap);
+    userdata.resize(model->nuserdata);
+
+    // policy
+    int num_max_parameter = model->nu * kMaxTrajectoryHorizon;
+    policy.Allocate(model, *task, kMaxTrajectoryHorizon);
+    resampled_policy.Allocate(model, *task, kMaxTrajectoryHorizon);
+    previous_policy.Allocate(model, *task, kMaxTrajectoryHorizon);
+
+    // scratch
+    parameters_scratch.resize(num_max_parameter);
+    times_scratch.resize(kMaxTrajectoryHorizon);
+
+    // noise
+    noise.resize(kMaxTrajectory * (model->nu * kMaxTrajectoryHorizon));
+
+    // variance
+    variance.resize(model->nu * kMaxTrajectoryHorizon); // (nu * horizon)
+
+    // need to initialize an arbitrary order of the trajectories
+    trajectory_order.resize(kMaxTrajectory);
+    for (int i = 0; i < kMaxTrajectory; i++)
+    {
+      trajectory_order[i] = i;
+    }
+
+    // trajectories and parameters
+    for (int i = 0; i < kMaxTrajectory; i++)
+    {
+      trajectory[i].Initialize(num_state, model->nu, task->num_residual,
+                               task->num_trace, kMaxTrajectoryHorizon);
+      trajectory[i].Allocate(kMaxTrajectoryHorizon);
+      candidate_policy[i].Allocate(model, *task, kMaxTrajectoryHorizon);
+    }
+    nominal_trajectory.Initialize(num_state, model->nu, task->num_residual,
+                                  task->num_trace, kMaxTrajectoryHorizon);
+    nominal_trajectory.Allocate(kMaxTrajectoryHorizon);
+  }
+
+  void CrossEntropyPlanner::Parameters(double *parameters)
   {
     const std::shared_lock<std::shared_mutex> lock(mtx_);
-    policy.plan.Clear();
-    policy.plan.SetInterpolation(interpolation_);
-    for (int t = 0; t < num_spline_points; t++) {
+    policy.Parameters(parameters);
+  }
+
+  // reset memory to zeros
+  void CrossEntropyPlanner::Reset(int horizon,
+                                  const double *initial_repeated_action)
+  {
+    // state
+    std::fill(state.begin(), state.end(), 0.0);
+    std::fill(mocap.begin(), mocap.end(), 0.0);
+    std::fill(userdata.begin(), userdata.end(), 0.0);
+    time = 0.0;
+
+    // policy parameters
+    policy.Reset(horizon, initial_repeated_action);
+    resampled_policy.Reset(horizon, initial_repeated_action);
+    previous_policy.Reset(horizon, initial_repeated_action);
+
+    // scratch
+    std::fill(parameters_scratch.begin(), parameters_scratch.end(), 0.0);
+    std::fill(times_scratch.begin(), times_scratch.end(), 0.0);
+
+    // noise
+    std::fill(noise.begin(), noise.end(), 0.0);
+
+    // variance
+    double var = std_initial_ * std_initial_;
+    std::fill(variance.begin(), variance.end(), var);
+
+    // trajectory samples
+    for (int i = 0; i < kMaxTrajectory; i++)
+    {
+      trajectory[i].Reset(kMaxTrajectoryHorizon);
+      candidate_policy[i].Reset(horizon);
+    }
+    nominal_trajectory.Reset(kMaxTrajectoryHorizon);
+
+    for (const auto &d : data_)
+    {
+      mju_zero(d->ctrl, model->nu);
+    }
+
+    // improvement
+    improvement = 0.0;
+  }
+
+  // set state
+  void CrossEntropyPlanner::SetState(const State &state)
+  {
+    state.CopyTo(this->state.data(), this->mocap.data(), this->userdata.data(),
+                 &this->time);
+  }
+
+  // optimize nominal policy using random sampling
+  void CrossEntropyPlanner::OptimizePolicy(int horizon, ThreadPool &pool)
+  {
+    resampled_policy.plan.SetInterpolation(interpolation_);
+
+    // if num_trajectory_ has changed, use it in this new iteration.
+    // num_trajectory_ might change while this function runs. Keep it constant
+    // for the duration of this function.
+    int num_trajectory = num_trajectory_;
+
+    // n_elite_ might change in the GUI - keep constant for in this function
+    n_elite_ = std::min(n_elite_, num_trajectory);
+    int n_elite = std::min(n_elite_, num_trajectory);
+
+    // resize number of mjData
+    ResizeMjData(model, pool.NumThreads());
+
+    // copy nominal policy
+    {
+      const std::shared_lock<std::shared_mutex> lock(mtx_);
+      resampled_policy.CopyFrom(policy, policy.num_spline_points);
+    }
+
+    // resample nominal policy to current time
+    this->ResamplePolicy(horizon);
+
+    // ----- rollout noisy policies ----- //
+    // start timer
+    auto rollouts_start = std::chrono::steady_clock::now();
+
+    // simulate noisy policies
+    this->Rollouts(num_trajectory, horizon, pool);
+
+    // sort candidate policies and trajectories by score
+    for (int i = 0; i < num_trajectory; i++)
+    {
+      trajectory_order[i] = i;
+    }
+
+    // sort so that the first ncandidates elements are the best candidates, and
+    // the rest are in an unspecified order
+    std::partial_sort(
+        trajectory_order.begin(), trajectory_order.begin() + num_trajectory,
+        trajectory_order.begin() + num_trajectory,
+        [&trajectory = trajectory](int a, int b)
+        {
+          return trajectory[a].total_return < trajectory[b].total_return;
+        });
+
+    // stop timer
+    rollouts_compute_time = GetDuration(rollouts_start);
+
+    // ----- update policy ----- //
+    // start timer
+    auto policy_update_start = std::chrono::steady_clock::now();
+
+    // dimensions
+    int num_spline_points = resampled_policy.num_spline_points;
+    int num_parameters = num_spline_points * model->nu;
+
+    // averaged return over elites
+    double avg_return = 0.0;
+
+    // reset parameters scratch
+    std::fill(parameters_scratch.begin(), parameters_scratch.end(), 0.0);
+
+    // loop over elites to compute average
+    for (int i = 0; i < n_elite; i++)
+    {
+      // ordered trajectory index
+      int idx = trajectory_order[i];
+
+      // add parameters
+      for (int i = 0; i < num_spline_points; i++)
+      {
+        TimeSpline::Node n = candidate_policy[idx].plan.NodeAt(i);
+        for (int j = 0; j < model->nu; j++)
+        {
+          parameters_scratch[i * model->nu + j] += n.values()[j];
+        }
+      }
+
+      // add total return
+      avg_return += trajectory[idx].total_return;
+    }
+
+    // normalize
+    mju_scl(parameters_scratch.data(), parameters_scratch.data(), 1.0 / n_elite,
+            num_parameters);
+    avg_return /= n_elite;
+
+    // loop over elites to compute variance
+    std::fill(variance.begin(), variance.end(), 0.0); // reset variance to zero
+    for (int t = 0; t < num_spline_points; t++)
+    {
+      TimeSpline::Node n = candidate_policy[trajectory_order[0]].plan.NodeAt(t);
+      for (int j = 0; j < model->nu; j++)
+      {
+        // average
+        double p_avg = parameters_scratch[t * model->nu + j];
+        for (int i = 0; i < n_elite; i++)
+        {
+          // candidate parameter
+          double pi = n.values()[j];
+          double diff = pi - p_avg;
+          variance[t * model->nu + j] += diff * diff / (n_elite - 1);
+        }
+      }
+    }
+
+    // update
+    {
+      const std::shared_lock<std::shared_mutex> lock(mtx_);
+      policy.plan.Clear();
+      policy.plan.SetInterpolation(interpolation_);
+      for (int t = 0; t < num_spline_points; t++)
+      {
+        absl::Span<const double> values =
+            absl::MakeConstSpan(parameters_scratch.data() + t * model->nu,
+                                parameters_scratch.data() + (t + 1) * model->nu);
+        policy.plan.AddNode(times_scratch[t], values);
+      }
+    }
+
+    // improvement: compare nominal to elite average
+    improvement =
+        mju_max(avg_return - trajectory[trajectory_order[0]].total_return, 0.0);
+
+    // stop timer
+    policy_update_compute_time = GetDuration(policy_update_start);
+  }
+
+  // compute trajectory using nominal policy
+  void CrossEntropyPlanner::NominalTrajectory(int horizon)
+  {
+    // set policy
+    auto nominal_policy = [&cp = resampled_policy](
+                              double *action, const double *state, double time)
+    {
+      cp.Action(action, state, time);
+    };
+
+    // rollout nominal policy
+    nominal_trajectory.Rollout(nominal_policy, task, model,
+                               data_[ThreadPool::WorkerId()].get(), state.data(),
+                               time, mocap.data(), userdata.data(), horizon);
+  }
+  void CrossEntropyPlanner::NominalTrajectory(int horizon, ThreadPool &pool)
+  {
+    NominalTrajectory(horizon);
+  }
+
+  // set action from policy
+  void CrossEntropyPlanner::ActionFromPolicy(double *action, const double *state,
+                                             double time, bool use_previous)
+  {
+    const std::shared_lock<std::shared_mutex> lock(mtx_);
+    if (use_previous)
+    {
+      previous_policy.Action(action, state, time);
+    }
+    else
+    {
+      policy.Action(action, state, time);
+    }
+  }
+
+  // update policy via resampling
+  void CrossEntropyPlanner::ResamplePolicy(int horizon)
+  {
+    // dimensions
+    int num_spline_points = resampled_policy.num_spline_points;
+
+    // time
+    double nominal_time = time;
+    double time_shift = mju_max(
+        (horizon - 1) * model->opt.timestep / (num_spline_points - 1), 1.0e-5);
+
+    // get spline points
+    for (int t = 0; t < num_spline_points; t++)
+    {
+      times_scratch[t] = nominal_time;
+      resampled_policy.Action(DataAt(parameters_scratch, t * model->nu), nullptr,
+                              nominal_time);
+      nominal_time += time_shift;
+    }
+
+    // copy resampled policy parameters
+    resampled_policy.plan.Clear();
+    for (int t = 0; t < num_spline_points; t++)
+    {
       absl::Span<const double> values =
           absl::MakeConstSpan(parameters_scratch.data() + t * model->nu,
                               parameters_scratch.data() + (t + 1) * model->nu);
-      policy.plan.AddNode(times_scratch[t], values);
+      resampled_policy.plan.AddNode(times_scratch[t], values);
     }
+    resampled_policy.plan.SetInterpolation(policy.plan.Interpolation());
   }
 
-  // improvement: compare nominal to elite average
-  improvement =
-      mju_max(avg_return - trajectory[trajectory_order[0]].total_return, 0.0);
+  // add random noise to nominal policy
+  void CrossEntropyPlanner::AddNoiseToPolicy(int i, double std_min)
+  {
+    // start timer
+    auto noise_start = std::chrono::steady_clock::now();
 
-  // stop timer
-  policy_update_compute_time = GetDuration(policy_update_start);
-}
+    // dimensions
+    int num_spline_points = candidate_policy[i].num_spline_points;
+    int num_parameters = num_spline_points * model->nu;
 
-// compute trajectory using nominal policy
-void CrossEntropyPlanner::NominalTrajectory(int horizon) {
-  // set policy
-  auto nominal_policy = [&cp = resampled_policy](
-                            double* action, const double* state, double time) {
-    cp.Action(action, state, time);
-  };
+    // sampling token
+    absl::BitGen gen_;
 
-  // rollout nominal policy
-  nominal_trajectory.Rollout(nominal_policy, task, model,
-                             data_[ThreadPool::WorkerId()].get(), state.data(),
-                             time, mocap.data(), userdata.data(), horizon);
-}
-void CrossEntropyPlanner::NominalTrajectory(int horizon, ThreadPool& pool) {
-  NominalTrajectory(horizon);
-}
+    // shift index
+    int shift = i * (model->nu * kMaxTrajectoryHorizon);
 
-// set action from policy
-void CrossEntropyPlanner::ActionFromPolicy(double* action, const double* state,
-                                           double time, bool use_previous) {
-  const std::shared_lock<std::shared_mutex> lock(mtx_);
-  if (use_previous) {
-    previous_policy.Action(action, state, time);
-  } else {
-    policy.Action(action, state, time);
-  }
-}
+    // sample noise
+    // variance[k] is the standard deviation for the k^th control parameter over
+    // the elite samples we draw a bunch of control actions from this distribution
+    // (which i indexes) - the noise is stored in `noise`.
+    for (int k = 0; k < num_parameters; k++)
+    {
+      noise[k + shift] = absl::Gaussian<double>(
+          gen_, 0.0, std::max(std::sqrt(variance[k]), std_min));
+    }
 
-// update policy via resampling
-void CrossEntropyPlanner::ResamplePolicy(int horizon) {
-  // dimensions
-  int num_spline_points = resampled_policy.num_spline_points;
+    for (int k = 0; k < candidate_policy[i].plan.Size(); k++)
+    {
+      TimeSpline::Node n = candidate_policy[i].plan.NodeAt(k);
+      // add noise
+      mju_addTo(n.values().data(), DataAt(noise, shift + k * model->nu),
+                model->nu);
+      // clamp parameters
+      Clamp(n.values().data(), model->actuator_ctrlrange, model->nu);
+    }
 
-  // time
-  double nominal_time = time;
-  double time_shift = mju_max(
-      (horizon - 1) * model->opt.timestep / (num_spline_points - 1), 1.0e-5);
-
-  // get spline points
-  for (int t = 0; t < num_spline_points; t++) {
-    times_scratch[t] = nominal_time;
-    resampled_policy.Action(DataAt(parameters_scratch, t * model->nu), nullptr,
-                            nominal_time);
-    nominal_time += time_shift;
+    // end timer
+    IncrementAtomic(noise_compute_time, GetDuration(noise_start));
   }
 
-  // copy resampled policy parameters
-  resampled_policy.plan.Clear();
-  for (int t = 0; t < num_spline_points; t++) {
-    absl::Span<const double> values =
-        absl::MakeConstSpan(parameters_scratch.data() + t * model->nu,
-                            parameters_scratch.data() + (t + 1) * model->nu);
-    resampled_policy.plan.AddNode(times_scratch[t], values);
-  }
-  resampled_policy.plan.SetInterpolation(policy.plan.Interpolation());
-}
+  // compute candidate trajectories
+  void CrossEntropyPlanner::Rollouts(int num_trajectory, int horizon,
+                                     ThreadPool &pool)
+  {
+    // reset noise compute time
+    noise_compute_time = 0.0;
 
-// add random noise to nominal policy
-void CrossEntropyPlanner::AddNoiseToPolicy(int i, double std_min) {
-  // start timer
-  auto noise_start = std::chrono::steady_clock::now();
+    // lock std_min
+    double std_min = std_min_;
 
-  // dimensions
-  int num_spline_points = candidate_policy[i].num_spline_points;
-  int num_parameters = num_spline_points * model->nu;
-
-  // sampling token
-  absl::BitGen gen_;
-
-  // shift index
-  int shift = i * (model->nu * kMaxTrajectoryHorizon);
-
-  // sample noise
-  // variance[k] is the standard deviation for the k^th control parameter over
-  // the elite samples we draw a bunch of control actions from this distribution
-  // (which i indexes) - the noise is stored in `noise`.
-  for (int k = 0; k < num_parameters; k++) {
-    noise[k + shift] = absl::Gaussian<double>(
-        gen_, 0.0, std::max(std::sqrt(variance[k]), std_min));
-  }
-
-  for (int k = 0; k < candidate_policy[i].plan.Size(); k++) {
-    TimeSpline::Node n = candidate_policy[i].plan.NodeAt(k);
-    // add noise
-    mju_addTo(n.values().data(), DataAt(noise, shift + k * model->nu),
-              model->nu);
-    // clamp parameters
-    Clamp(n.values().data(), model->actuator_ctrlrange, model->nu);
-  }
-
-  // end timer
-  IncrementAtomic(noise_compute_time, GetDuration(noise_start));
-}
-
-// compute candidate trajectories
-void CrossEntropyPlanner::Rollouts(int num_trajectory, int horizon,
-                                   ThreadPool& pool) {
-  // reset noise compute time
-  noise_compute_time = 0.0;
-
-  // lock std_min
-  double std_min = std_min_;
-
-  // random search
-  int count_before = pool.GetCount();
-  for (int i = 0; i < num_trajectory; i++) {
-    pool.Schedule([&s = *this, &model = this->model, &task = this->task,
-                   &state = this->state, &time = this->time,
-                   &mocap = this->mocap, &userdata = this->userdata, horizon,
-                   std_min, i]() {
+    // random search
+    int count_before = pool.GetCount();
+    for (int i = 0; i < num_trajectory; i++)
+    {
+      pool.Schedule([&s = *this, &model = this->model, &task = this->task,
+                     &state = this->state, &time = this->time,
+                     &mocap = this->mocap, &userdata = this->userdata, horizon,
+                     std_min, i]()
+                    {
       // copy nominal policy and sample noise
       {
         const std::shared_lock<std::shared_mutex> lock(s.mtx_);
@@ -419,146 +461,154 @@ void CrossEntropyPlanner::Rollouts(int num_trajectory, int horizon,
       // policy rollout
       s.trajectory[i].Rollout(
           sample_policy_i, task, model, s.data_[ThreadPool::WorkerId()].get(),
-          state.data(), time, mocap.data(), userdata.data(), horizon);
-    });
+          state.data(), time, mocap.data(), userdata.data(), horizon); });
+    }
+    // nominal
+    pool.Schedule([&s = *this, horizon]()
+                  { s.NominalTrajectory(horizon); });
+
+    // wait
+    pool.WaitCount(count_before + num_trajectory + 1);
+    pool.ResetCount();
   }
-  // nominal
-  pool.Schedule([&s = *this, horizon]() { s.NominalTrajectory(horizon); });
 
-  // wait
-  pool.WaitCount(count_before + num_trajectory + 1);
-  pool.ResetCount();
-}
+  // returns the **nominal** trajectory (this is the purple trace)
+  const Trajectory *CrossEntropyPlanner::BestTrajectory()
+  {
+    return &nominal_trajectory;
+  }
 
-// returns the **nominal** trajectory (this is the purple trace)
-const Trajectory* CrossEntropyPlanner::BestTrajectory() {
-  return &nominal_trajectory;
-}
+  // visualize planner-specific traces
+  void CrossEntropyPlanner::Traces(mjvScene *scn)
+  {
+    // sample color
+    float color[4];
+    color[0] = 1.0;
+    color[1] = 1.0;
+    color[2] = 1.0;
+    color[3] = 1.0;
 
-// visualize planner-specific traces
-void CrossEntropyPlanner::Traces(mjvScene* scn) {
-  // sample color
-  float color[4];
-  color[0] = 1.0;
-  color[1] = 1.0;
-  color[2] = 1.0;
-  color[3] = 1.0;
+    // width of a sample trace, in pixels
+    double width = GetNumberOrDefault(3, model, "agent_sample_width");
 
-  // width of a sample trace, in pixels
-  double width = GetNumberOrDefault(3, model, "agent_sample_width");
+    // scratch
+    double zero3[3] = {0};
+    double zero9[9] = {0};
 
-  // scratch
-  double zero3[3] = {0};
-  double zero9[9] = {0};
+    // best
+    auto best = this->BestTrajectory();
 
-  // best
-  auto best = this->BestTrajectory();
+    // sample traces
+    int n_elite = n_elite_;
+    for (int k = 0; k < n_elite; k++)
+    {
+      // plot sample
+      for (int i = 0; i < best->horizon - 1; i++)
+      {
+        if (scn->ngeom + task->num_trace > scn->maxgeom)
+          break;
+        for (int j = 0; j < task->num_trace; j++)
+        {
+          // initialize geometry
+          mjv_initGeom(&scn->geoms[scn->ngeom], mjGEOM_LINE, zero3, zero3, zero9,
+                       color);
 
-  // sample traces
-  int n_elite = n_elite_;
-  for (int k = 0; k < n_elite; k++) {
-    // plot sample
-    for (int i = 0; i < best->horizon - 1; i++) {
-      if (scn->ngeom + task->num_trace > scn->maxgeom) break;
-      for (int j = 0; j < task->num_trace; j++) {
-        // initialize geometry
-        mjv_initGeom(&scn->geoms[scn->ngeom], mjGEOM_LINE, zero3, zero3, zero9,
-                     color);
+          // elite index
+          int idx = trajectory_order[k];
+          // make geometry
+          mjv_makeConnector(
+              &scn->geoms[scn->ngeom], mjGEOM_LINE, width,
+              trajectory[idx].trace[3 * task->num_trace * i + 3 * j],
+              trajectory[idx].trace[3 * task->num_trace * i + 1 + 3 * j],
+              trajectory[idx].trace[3 * task->num_trace * i + 2 + 3 * j],
+              trajectory[idx].trace[3 * task->num_trace * (i + 1) + 3 * j],
+              trajectory[idx].trace[3 * task->num_trace * (i + 1) + 1 + 3 * j],
+              trajectory[idx].trace[3 * task->num_trace * (i + 1) + 2 + 3 * j]);
 
-        // elite index
-        int idx = trajectory_order[k];
-        // make geometry
-        mjv_makeConnector(
-            &scn->geoms[scn->ngeom], mjGEOM_LINE, width,
-            trajectory[idx].trace[3 * task->num_trace * i + 3 * j],
-            trajectory[idx].trace[3 * task->num_trace * i + 1 + 3 * j],
-            trajectory[idx].trace[3 * task->num_trace * i + 2 + 3 * j],
-            trajectory[idx].trace[3 * task->num_trace * (i + 1) + 3 * j],
-            trajectory[idx].trace[3 * task->num_trace * (i + 1) + 1 + 3 * j],
-            trajectory[idx].trace[3 * task->num_trace * (i + 1) + 2 + 3 * j]);
-
-        // increment number of geometries
-        scn->ngeom += 1;
+          // increment number of geometries
+          scn->ngeom += 1;
+        }
       }
     }
   }
-}
 
-// planner-specific GUI elements
-void CrossEntropyPlanner::GUI(mjUI& ui) {
-  mjuiDef defCrossEntropy[] = {
-      {mjITEM_SLIDERINT, "Rollouts", 2, &num_trajectory_, "0 1"},
-      {mjITEM_SELECT, "Spline", 2, &interpolation_,
-       "Zero\nLinear\nCubic"},
-      {mjITEM_SLIDERINT, "Spline Pts", 2, &policy.num_spline_points, "0 1"},
-      {mjITEM_SLIDERNUM, "Init. Std", 2, &std_initial_, "0 1"},
-      {mjITEM_SLIDERNUM, "Min. Std", 2, &std_min_, "0.01 0.5"},
-      {mjITEM_SLIDERINT, "Elite", 2, &n_elite_, "2 128"},
-      {mjITEM_END}};
+  // planner-specific GUI elements
+  void CrossEntropyPlanner::GUI(mjUI &ui)
+  {
+    mjuiDef defCrossEntropy[] = {
+        {mjITEM_SLIDERINT, "Rollouts", 2, &num_trajectory_, "0 1"},
+        {mjITEM_SELECT, "Spline", 2, &interpolation_,
+         "Zero\nLinear\nCubic"},
+        {mjITEM_SLIDERINT, "Spline Pts", 2, &policy.num_spline_points, "0 1"},
+        {mjITEM_SLIDERNUM, "Init. Std", 2, &std_initial_, "0 1"},
+        {mjITEM_SLIDERNUM, "Min. Std", 2, &std_min_, "0.01 0.5"},
+        {mjITEM_SLIDERINT, "Elite", 2, &n_elite_, "2 128"},
+        {mjITEM_END}};
 
-  // set number of trajectory slider limits
-  mju::sprintf_arr(defCrossEntropy[0].other, "%i %i", 1, kMaxTrajectory);
+    // set number of trajectory slider limits
+    mju::sprintf_arr(defCrossEntropy[0].other, "%i %i", 1, kMaxTrajectory);
 
-  // set spline point limits
-  mju::sprintf_arr(defCrossEntropy[2].other, "%i %i", MinSamplingSplinePoints,
-                   MaxSamplingSplinePoints);
+    // set spline point limits
+    mju::sprintf_arr(defCrossEntropy[2].other, "%i %i", MinSamplingSplinePoints,
+                     MaxSamplingSplinePoints);
 
-  // set noise standard deviation limits
-  mju::sprintf_arr(defCrossEntropy[3].other, "%f %f", MinNoiseStdDev,
-                   MaxNoiseStdDev);
+    // set noise standard deviation limits
+    mju::sprintf_arr(defCrossEntropy[3].other, "%f %f", MinNoiseStdDev,
+                     MaxNoiseStdDev);
 
-  // add cross entropy planner
-  mjui_add(&ui, defCrossEntropy);
-}
+    // add cross entropy planner
+    mjui_add(&ui, defCrossEntropy);
+  }
 
-// planner-specific plots
-void CrossEntropyPlanner::Plots(mjvFigure* fig_planner, mjvFigure* fig_timer,
-                                int planner_shift, int timer_shift,
-                                int planning, int* shift) {
-  // ----- planner ----- //
-  double planner_bounds[2] = {-6.0, 6.0};
+  // planner-specific plots
+  void CrossEntropyPlanner::Plots(mjvFigure *fig_planner, mjvFigure *fig_timer,
+                                  int planner_shift, int timer_shift,
+                                  int planning, int *shift)
+  {
+    // ----- planner ----- //
+    double planner_bounds[2] = {-6.0, 6.0};
 
-  // improvement
-  mjpc::PlotUpdateData(fig_planner, planner_bounds,
-                       fig_planner->linedata[0 + planner_shift][0] + 1,
-                       mju_log10(mju_max(improvement, 1.0e-6)), 100,
-                       0 + planner_shift, 0, 1, -100);
+    // improvement
+    mjpc::PlotUpdateData(fig_planner, planner_bounds,
+                         fig_planner->linedata[0 + planner_shift][0] + 1,
+                         mju_log10(mju_max(improvement, 1.0e-6)), 100,
+                         0 + planner_shift, 0, 1, -100);
 
-  // legend
-  mju::strcpy_arr(fig_planner->linename[0 + planner_shift], "Avg - Best");
+    // legend
+    mju::strcpy_arr(fig_planner->linename[0 + planner_shift], "Avg - Best");
 
-  fig_planner->range[1][0] = planner_bounds[0];
-  fig_planner->range[1][1] = planner_bounds[1];
+    fig_planner->range[1][0] = planner_bounds[0];
+    fig_planner->range[1][1] = planner_bounds[1];
 
-  // bounds
-  double timer_bounds[2] = {0.0, 1.0};
+    // bounds
+    double timer_bounds[2] = {0.0, 1.0};
 
-  // ----- timer ----- //
+    // ----- timer ----- //
 
-  PlotUpdateData(
-      fig_timer, timer_bounds, fig_timer->linedata[0 + timer_shift][0] + 1,
-      1.0e-3 * noise_compute_time * planning, 100, 0 + timer_shift, 0, 1, -100);
+    PlotUpdateData(
+        fig_timer, timer_bounds, fig_timer->linedata[0 + timer_shift][0] + 1,
+        1.0e-3 * noise_compute_time * planning, 100, 0 + timer_shift, 0, 1, -100);
 
-  PlotUpdateData(fig_timer, timer_bounds,
-                 fig_timer->linedata[1 + timer_shift][0] + 1,
-                 1.0e-3 * rollouts_compute_time * planning, 100,
-                 1 + timer_shift, 0, 1, -100);
+    PlotUpdateData(fig_timer, timer_bounds,
+                   fig_timer->linedata[1 + timer_shift][0] + 1,
+                   1.0e-3 * rollouts_compute_time * planning, 100,
+                   1 + timer_shift, 0, 1, -100);
 
-  PlotUpdateData(fig_timer, timer_bounds,
-                 fig_timer->linedata[2 + timer_shift][0] + 1,
-                 1.0e-3 * policy_update_compute_time * planning, 100,
-                 2 + timer_shift, 0, 1, -100);
+    PlotUpdateData(fig_timer, timer_bounds,
+                   fig_timer->linedata[2 + timer_shift][0] + 1,
+                   1.0e-3 * policy_update_compute_time * planning, 100,
+                   2 + timer_shift, 0, 1, -100);
 
-  // legend
-  mju::strcpy_arr(fig_timer->linename[0 + timer_shift], "Noise");
-  mju::strcpy_arr(fig_timer->linename[1 + timer_shift], "Rollout");
-  mju::strcpy_arr(fig_timer->linename[2 + timer_shift], "Policy Update");
+    // legend
+    mju::strcpy_arr(fig_timer->linename[0 + timer_shift], "Noise");
+    mju::strcpy_arr(fig_timer->linename[1 + timer_shift], "Rollout");
+    mju::strcpy_arr(fig_timer->linename[2 + timer_shift], "Policy Update");
 
-  // planner shift
-  shift[0] += 1;
+    // planner shift
+    shift[0] += 1;
 
-  // timer shift
-  shift[1] += 3;
-}
+    // timer shift
+    shift[1] += 3;
+  }
 
-}  // namespace mjpc
+} // namespace mjpc

--- a/mjpc/planners/cross_entropy/planner.h
+++ b/mjpc/planners/cross_entropy/planner.h
@@ -28,120 +28,126 @@
 #include "mjpc/threadpool.h"
 #include "mjpc/trajectory.h"
 
-namespace mjpc {
+namespace mjpc
+{
 
-class CrossEntropyPlanner : public Planner {
- public:
-  // constructor
-  CrossEntropyPlanner() = default;
+  class CrossEntropyPlanner : public Planner
+  {
+  public:
+    // constructor
+    CrossEntropyPlanner() = default;
 
-  // destructor
-  ~CrossEntropyPlanner() override = default;
+    // destructor
+    ~CrossEntropyPlanner() override = default;
 
-  // ----- methods ----- //
+    // ----- methods ----- //
 
-  // initialize data and settings
-  void Initialize(mjModel* model, const Task& task) override;
+    // initialize data and settings
+    void Initialize(mjModel *model, const Task &task) override;
 
-  // allocate memory
-  void Allocate() override;
+    // allocate memory
+    void Allocate() override;
 
-  // reset memory to zeros
-  void Reset(int horizon,
-             const double* initial_repeated_action = nullptr) override;
+    // reset memory to zeros
+    void Reset(int horizon,
+               const double *initial_repeated_action = nullptr) override;
 
-  // set state
-  void SetState(const State& state) override;
+    // set state
+    void SetState(const State &state) override;
 
-  // optimize nominal policy using random sampling
-  void OptimizePolicy(int horizon, ThreadPool& pool) override;
+    // optimize nominal policy using random sampling
+    void OptimizePolicy(int horizon, ThreadPool &pool) override;
 
-  // compute trajectory using nominal policy
-  void NominalTrajectory(int horizon, ThreadPool& pool) override;
-  void NominalTrajectory(int horizon);
+    // compute trajectory using nominal policy
+    void NominalTrajectory(int horizon, ThreadPool &pool) override;
+    void NominalTrajectory(int horizon);
 
-  // set action from policy
-  void ActionFromPolicy(double* action, const double* state, double time,
-                        bool use_previous = false) override;
+    // set action from policy
+    void ActionFromPolicy(double *action, const double *state, double time,
+                          bool use_previous = false) override;
 
-  // resample nominal policy
-  void ResamplePolicy(int horizon);
+    // resample nominal policy
+    void ResamplePolicy(int horizon);
 
-  // add noise to nominal policy
-  void AddNoiseToPolicy(int i, double std_min);
+    // add noise to nominal policy
+    void AddNoiseToPolicy(int i, double std_min);
 
-  // compute candidate trajectories
-  void Rollouts(int num_trajectory, int horizon, ThreadPool& pool);
+    // compute candidate trajectories
+    void Rollouts(int num_trajectory, int horizon, ThreadPool &pool);
 
-  // return trajectory with best total return
-  const Trajectory* BestTrajectory() override;
+    // return trajectory with best total return
+    const Trajectory *BestTrajectory() override;
 
-  // visualize planner-specific traces
-  void Traces(mjvScene* scn) override;
+    // visualize planner-specific traces
+    void Traces(mjvScene *scn) override;
 
-  // planner-specific GUI elements
-  void GUI(mjUI& ui) override;
+    // return parameters of current policy
+    void Parameters(double *parameters);
 
-  // planner-specific plots
-  void Plots(mjvFigure* fig_planner, mjvFigure* fig_timer, int planner_shift,
-             int timer_shift, int planning, int* shift) override;
+    // planner-specific GUI elements
+    void GUI(mjUI &ui) override;
 
-  // return number of parameters optimized by planner
-  int NumParameters() override {
-    return policy.num_spline_points * policy.model->nu;
+    // planner-specific plots
+    void Plots(mjvFigure *fig_planner, mjvFigure *fig_timer, int planner_shift,
+               int timer_shift, int planning, int *shift) override;
+
+    // return number of parameters optimized by planner
+    int NumParameters() override
+    {
+      return policy.num_spline_points * policy.model->nu;
+    };
+
+    // ----- members ----- //
+    mjModel *model;
+    const Task *task;
+
+    // state
+    std::vector<double> state;
+    double time;
+    std::vector<double> mocap;
+    std::vector<double> userdata;
+
+    // policy
+    SamplingPolicy policy; // (Guarded by mtx_)
+    SamplingPolicy candidate_policy[kMaxTrajectory];
+    SamplingPolicy resampled_policy;
+    SamplingPolicy previous_policy;
+
+    // scratch
+    std::vector<double> parameters_scratch;
+    std::vector<double> times_scratch;
+
+    // trajectories
+    Trajectory trajectory[kMaxTrajectory];
+    Trajectory nominal_trajectory;
+
+    // order of indices of rolled out trajectories, ordered by total return
+    std::vector<int> trajectory_order;
+
+    // ----- noise ----- //
+    double std_initial_; // standard deviation for sampling normal: N(0,
+                         // std)
+    double std_min_;     // the minimum allowable std
+    std::vector<double> noise;
+    std::vector<double> variance;
+
+    // number of elite samples
+    int n_elite_;
+
+    // improvement
+    double improvement;
+
+    // timing
+    std::atomic<double> noise_compute_time;
+    double rollouts_compute_time;
+    double policy_update_compute_time;
+
+    mjpc::spline::SplineInterpolation interpolation_ =
+        mjpc::spline::SplineInterpolation::kZeroSpline;
+    int num_trajectory_;
+    mutable std::shared_mutex mtx_;
   };
 
-  // ----- members ----- //
-  mjModel* model;
-  const Task* task;
+} // namespace mjpc
 
-  // state
-  std::vector<double> state;
-  double time;
-  std::vector<double> mocap;
-  std::vector<double> userdata;
-
-  // policy
-  SamplingPolicy policy;  // (Guarded by mtx_)
-  SamplingPolicy candidate_policy[kMaxTrajectory];
-  SamplingPolicy resampled_policy;
-  SamplingPolicy previous_policy;
-
-  // scratch
-  std::vector<double> parameters_scratch;
-  std::vector<double> times_scratch;
-
-  // trajectories
-  Trajectory trajectory[kMaxTrajectory];
-  Trajectory nominal_trajectory;
-
-  // order of indices of rolled out trajectories, ordered by total return
-  std::vector<int> trajectory_order;
-
-  // ----- noise ----- //
-  double std_initial_;  // standard deviation for sampling normal: N(0,
-                        // std)
-  double std_min_;      // the minimum allowable std
-  std::vector<double> noise;
-  std::vector<double> variance;
-
-  // number of elite samples
-  int n_elite_;
-
-  // improvement
-  double improvement;
-
-  // timing
-  std::atomic<double> noise_compute_time;
-  double rollouts_compute_time;
-  double policy_update_compute_time;
-
-  mjpc::spline::SplineInterpolation interpolation_ =
-      mjpc::spline::SplineInterpolation::kZeroSpline;
-  int num_trajectory_;
-  mutable std::shared_mutex mtx_;
-};
-
-}  // namespace mjpc
-
-#endif  // MJPC_PLANNERS_CROSS_ENTROPY_PLANNER_H_
+#endif // MJPC_PLANNERS_CROSS_ENTROPY_PLANNER_H_

--- a/mjpc/planners/cross_entropy/planner.h
+++ b/mjpc/planners/cross_entropy/planner.h
@@ -82,7 +82,7 @@ namespace mjpc
     void Traces(mjvScene *scn) override;
 
     // return parameters of current policy
-    void Parameters(double *parameters);
+    void Parameters(double *parameters) override;
 
     // planner-specific GUI elements
     void GUI(mjUI &ui) override;

--- a/mjpc/planners/planner.cc
+++ b/mjpc/planners/planner.cc
@@ -19,16 +19,22 @@
 #include <mujoco/mujoco.h>
 #include "mjpc/utilities.h"
 
-namespace mjpc {
-void Planner::ResizeMjData(const mjModel* model, int num_threads) {
-  int new_size = std::max(1, num_threads);
-  if (data_.size() > new_size) {
-    data_.erase(data_.begin() + new_size, data_.end());
-  } else {
-    data_.reserve(new_size);
-    while (data_.size() < new_size) {
-      data_.push_back(MakeUniqueMjData(mj_makeData(model)));
+namespace mjpc
+{
+  void Planner::ResizeMjData(const mjModel *model, int num_threads)
+  {
+    int new_size = std::max(1, num_threads);
+    if (data_.size() > new_size)
+    {
+      data_.erase(data_.begin() + new_size, data_.end());
+    }
+    else
+    {
+      data_.reserve(new_size);
+      while (data_.size() < new_size)
+      {
+        data_.push_back(MakeUniqueMjData(mj_makeData(model)));
+      }
     }
   }
-}
-}  // namespace mjpc
+} // namespace mjpc

--- a/mjpc/planners/planner.h
+++ b/mjpc/planners/planner.h
@@ -71,7 +71,7 @@ namespace mjpc
 
     // general callback to return planner-specific policy parameters
     // do nothing if no parameters.
-    void Parameters(double *parameters) {
+    virtual void Parameters(double *parameters) {
       // do nothing
     }
 

--- a/mjpc/planners/planner.h
+++ b/mjpc/planners/planner.h
@@ -23,84 +23,93 @@
 #include "mjpc/trajectory.h"
 #include "mjpc/utilities.h"
 
-namespace mjpc {
+namespace mjpc
+{
 
-inline constexpr int kMaxTrajectory = 128;
-inline constexpr int kMaxTrajectoryLarge = 1028;
+  inline constexpr int kMaxTrajectory = 128;
+  inline constexpr int kMaxTrajectoryLarge = 1028;
 
-// virtual planner
-class Planner {
- public:
-  // destructor
-  virtual ~Planner() = default;
+  // virtual planner
+  class Planner
+  {
+  public:
+    // destructor
+    virtual ~Planner() = default;
 
-  // initialize data and settings
-  virtual void Initialize(mjModel* model, const Task& task) = 0;
+    // initialize data and settings
+    virtual void Initialize(mjModel *model, const Task &task) = 0;
 
-  // allocate memory
-  virtual void Allocate() = 0;
+    // allocate memory
+    virtual void Allocate() = 0;
 
-  // reset memory to zeros
-  virtual void Reset(int horizon,
-                     const double* initial_repeated_action = nullptr) = 0;
+    // reset memory to zeros
+    virtual void Reset(int horizon,
+                       const double *initial_repeated_action = nullptr) = 0;
 
-  // set state
-  virtual void SetState(const State& state) = 0;
+    // set state
+    virtual void SetState(const State &state) = 0;
 
-  // optimize nominal policy
-  virtual void OptimizePolicy(int horizon, ThreadPool& pool) = 0;
+    // optimize nominal policy
+    virtual void OptimizePolicy(int horizon, ThreadPool &pool) = 0;
 
-  // compute trajectory using nominal policy
-  virtual void NominalTrajectory(int horizon, ThreadPool& pool) = 0;
+    // compute trajectory using nominal policy
+    virtual void NominalTrajectory(int horizon, ThreadPool &pool) = 0;
 
-  // set action from policy
-  virtual void ActionFromPolicy(double* action, const double* state,
-                                double time, bool use_previous = false) = 0;
+    // set action from policy
+    virtual void ActionFromPolicy(double *action, const double *state,
+                                  double time, bool use_previous = false) = 0;
 
-  // return trajectory with best total return, or nullptr if no planning
-  // iteration has completed
-  virtual const Trajectory* BestTrajectory() = 0;
+    // return trajectory with best total return, or nullptr if no planning
+    // iteration has completed
+    virtual const Trajectory *BestTrajectory() = 0;
 
-  // visualize planner-specific traces
-  virtual void Traces(mjvScene* scn) = 0;
+    // visualize planner-specific traces
+    virtual void Traces(mjvScene *scn) = 0;
 
-  // planner-specific GUI elements
-  virtual void GUI(mjUI& ui) = 0;
+    // planner-specific GUI elements
+    virtual void GUI(mjUI &ui) = 0;
 
-  // planner-specific plots
-  virtual void Plots(mjvFigure* fig_planner, mjvFigure* fig_timer,
-                     int planner_shift, int timer_shift, int planning,
-                     int* shift) = 0;
+    // general callback to return planner-specific policy parameters
+    // do nothing if no parameters.
+    void Parameters(double *parameters) {
+      // do nothing
+    }
 
-  // return number of parameters optimized by planner
-  virtual int NumParameters() = 0;
+    // planner-specific plots
+    virtual void Plots(mjvFigure *fig_planner, mjvFigure *fig_timer,
+                       int planner_shift, int timer_shift, int planning,
+                       int *shift) = 0;
 
-  std::vector<UniqueMjData> data_;
-  void ResizeMjData(const mjModel* model, int num_threads);
-};
+    // return number of parameters optimized by planner
+    virtual int NumParameters() = 0;
 
-// additional optional interface for planners that can produce several policy
-// proposals
-class RankedPlanner : public Planner {
- public:
-  virtual ~RankedPlanner() = default;
-  // optimizes policies, but rather than picking the best, generate up to
-  // ncandidates. returns number of candidates created. only called
-  // from the planning thread.
-  virtual int OptimizePolicyCandidates(int ncandidates, int horizon,
-                                        ThreadPool& pool) = 0;
-  // returns the total return for the nth candidate (or another score to
-  // minimize). only called from the planning thread.
-  virtual double CandidateScore(int candidate) const = 0;
+    std::vector<UniqueMjData> data_;
+    void ResizeMjData(const mjModel *model, int num_threads);
+  };
 
-  // set action from candidate policy. only called from the planning thread.
-  virtual void ActionFromCandidatePolicy(double* action, int candidate,
-                                         const double* state, double time) = 0;
+  // additional optional interface for planners that can produce several policy
+  // proposals
+  class RankedPlanner : public Planner
+  {
+  public:
+    virtual ~RankedPlanner() = default;
+    // optimizes policies, but rather than picking the best, generate up to
+    // ncandidates. returns number of candidates created. only called
+    // from the planning thread.
+    virtual int OptimizePolicyCandidates(int ncandidates, int horizon,
+                                         ThreadPool &pool) = 0;
+    // returns the total return for the nth candidate (or another score to
+    // minimize). only called from the planning thread.
+    virtual double CandidateScore(int candidate) const = 0;
 
-  // sets the nth candidate to the active policy.
-  virtual void CopyCandidateToPolicy(int candidate) = 0;
-};
+    // set action from candidate policy. only called from the planning thread.
+    virtual void ActionFromCandidatePolicy(double *action, int candidate,
+                                           const double *state, double time) = 0;
 
-}  // namespace mjpc
+    // sets the nth candidate to the active policy.
+    virtual void CopyCandidateToPolicy(int candidate) = 0;
+  };
 
-#endif  // MJPC_PLANNERS_PLANNER_H_
+} // namespace mjpc
+
+#endif // MJPC_PLANNERS_PLANNER_H_

--- a/mjpc/planners/policy.h
+++ b/mjpc/planners/policy.h
@@ -45,7 +45,7 @@ namespace mjpc
         // get policy parameters
         // general callback to return planner-specific policy parameters
         // do nothing if no parameters.
-        void Parameters(double *parameters) const
+        virtual void Parameters(double *parameters) const
         {
             // do nothing
         }

--- a/mjpc/planners/policy.h
+++ b/mjpc/planners/policy.h
@@ -18,29 +18,39 @@
 #include <mujoco/mjmodel.h>
 #include "mjpc/task.h"
 
-namespace mjpc {
+namespace mjpc
+{
 
-// virtual policy
-class Policy {
- public:
-  // destructor
-  virtual ~Policy() = default;
+    // virtual policy
+    class Policy
+    {
+    public:
+        // destructor
+        virtual ~Policy() = default;
 
-  // allocate memory
-  virtual void Allocate(const mjModel* model, const Task& task,
-                        int horizon) = 0;
+        // allocate memory
+        virtual void Allocate(const mjModel *model, const Task &task,
+                              int horizon) = 0;
 
-  // reset memory to zeros
-  virtual void Reset(int horizon,
-                     const double* initial_repeated_action = nullptr) = 0;
+        // reset memory to zeros
+        virtual void Reset(int horizon,
+                           const double *initial_repeated_action = nullptr) = 0;
 
-  // set action from policy
-  // for policies that have a feedback term, passing nullptr for state  turns
-  // the feedback term off and returns the nominal action for that time
-  virtual void Action(double* action, const double* state,
-                      double time) const = 0;
-};
+        // set action from policy
+        // for policies that have a feedback term, passing nullptr for state  turns
+        // the feedback term off and returns the nominal action for that time
+        virtual void Action(double *action, const double *state,
+                            double time) const = 0;
 
-}  // namespace mjpc
+        // get policy parameters
+        // general callback to return planner-specific policy parameters
+        // do nothing if no parameters.
+        void Parameters(double *parameters) const
+        {
+            // do nothing
+        }
+    };
 
-#endif  // MJPC_PLANNERS_POLICY_H_
+} // namespace mjpc
+
+#endif // MJPC_PLANNERS_POLICY_H_

--- a/mjpc/planners/sampling/planner.cc
+++ b/mjpc/planners/sampling/planner.cc
@@ -30,221 +30,245 @@
 #include "mjpc/trajectory.h"
 #include "mjpc/utilities.h"
 
-namespace mjpc {
+namespace mjpc
+{
 
-namespace mju = ::mujoco::util_mjpc;
-using mjpc::spline::SplineInterpolation;
-using mjpc::spline::TimeSpline;
+  namespace mju = ::mujoco::util_mjpc;
+  using mjpc::spline::SplineInterpolation;
+  using mjpc::spline::TimeSpline;
 
-// initialize data and settings
-void SamplingPlanner::Initialize(mjModel* model, const Task& task) {
-  // delete mjData instances since model might have changed.
-  data_.clear();
-  // allocate one mjData for nominal.
-  ResizeMjData(model, 1);
+  // initialize data and settings
+  void SamplingPlanner::Initialize(mjModel *model, const Task &task)
+  {
+    // delete mjData instances since model might have changed.
+    data_.clear();
+    // allocate one mjData for nominal.
+    ResizeMjData(model, 1);
 
-  // model
-  this->model = model;
+    // model
+    this->model = model;
 
-  // task
-  this->task = &task;
+    // task
+    this->task = &task;
 
-  // sampling noise std
-  noise_exploration[0] = GetNumberOrDefault(0.1, model, "sampling_exploration");
+    // sampling noise std
+    noise_exploration[0] = GetNumberOrDefault(0.1, model, "sampling_exploration");
 
-  // optional second std (defaults to 0)
-  int se_id = mj_name2id(model, mjOBJ_NUMERIC, "sampling_exploration");
-  if (se_id >= 0 && model->numeric_size[se_id] > 1) {
-    int se_adr = model->numeric_adr[se_id];
-    noise_exploration[1] = model->numeric_data[se_adr+1];
+    // optional second std (defaults to 0)
+    int se_id = mj_name2id(model, mjOBJ_NUMERIC, "sampling_exploration");
+    if (se_id >= 0 && model->numeric_size[se_id] > 1)
+    {
+      int se_adr = model->numeric_adr[se_id];
+      noise_exploration[1] = model->numeric_data[se_adr + 1];
+    }
+
+    // set number of trajectories to rollout
+    num_trajectory_ = GetNumberOrDefault(10, model, "sampling_trajectories");
+
+    interpolation_ = GetNumberOrDefault(SplineInterpolation::kCubicSpline, model,
+                                        "sampling_representation");
+    sliding_plan_ = GetNumberOrDefault(0, model, "sampling_sliding_plan");
+
+    if (num_trajectory_ > kMaxTrajectory)
+    {
+      mju_error_i("Too many trajectories, %d is the maximum allowed.",
+                  kMaxTrajectory);
+    }
+
+    winner = 0;
   }
 
-  // set number of trajectories to rollout
-  num_trajectory_ = GetNumberOrDefault(10, model, "sampling_trajectories");
+  // allocate memory
+  void SamplingPlanner::Allocate()
+  {
+    // initial state
+    int num_state = model->nq + model->nv + model->na;
 
-  interpolation_ = GetNumberOrDefault(SplineInterpolation::kCubicSpline, model,
-                                      "sampling_representation");
-  sliding_plan_ = GetNumberOrDefault(0, model, "sampling_sliding_plan");
+    // state
+    state.resize(num_state);
+    mocap.resize(7 * model->nmocap);
+    userdata.resize(model->nuserdata);
 
-  if (num_trajectory_ > kMaxTrajectory) {
-    mju_error_i("Too many trajectories, %d is the maximum allowed.",
-                kMaxTrajectory);
-  }
+    // policy
+    policy.Allocate(model, *task, kMaxTrajectoryHorizon);
+    previous_policy.Allocate(model, *task, kMaxTrajectoryHorizon);
+    plan_scratch = TimeSpline(/*dim=*/model->nu);
 
-  winner = 0;
-}
+    // noise
+    noise.resize(kMaxTrajectory * (model->nu * kMaxTrajectoryHorizon));
 
-// allocate memory
-void SamplingPlanner::Allocate() {
-  // initial state
-  int num_state = model->nq + model->nv + model->na;
-
-  // state
-  state.resize(num_state);
-  mocap.resize(7 * model->nmocap);
-  userdata.resize(model->nuserdata);
-
-  // policy
-  policy.Allocate(model, *task, kMaxTrajectoryHorizon);
-  previous_policy.Allocate(model, *task, kMaxTrajectoryHorizon);
-  plan_scratch = TimeSpline(/*dim=*/model->nu);
-
-  // noise
-  noise.resize(kMaxTrajectory * (model->nu * kMaxTrajectoryHorizon));
-
-  // trajectory and parameters
-  winner = -1;
-  for (int i = 0; i < kMaxTrajectory; i++) {
-    trajectory[i].Initialize(num_state, model->nu, task->num_residual,
-                             task->num_trace, kMaxTrajectoryHorizon);
-    trajectory[i].Allocate(kMaxTrajectoryHorizon);
-    candidate_policy[i].Allocate(model, *task, kMaxTrajectoryHorizon);
-  }
-}
-
-// reset memory to zeros
-void SamplingPlanner::Reset(int horizon,
-                            const double* initial_repeated_action) {
-  // state
-  std::fill(state.begin(), state.end(), 0.0);
-  std::fill(mocap.begin(), mocap.end(), 0.0);
-  std::fill(userdata.begin(), userdata.end(), 0.0);
-  time = 0.0;
-
-  // policy parameters
-  policy.Reset(horizon, initial_repeated_action);
-  previous_policy.Reset(horizon, initial_repeated_action);
-
-  // scratch
-  plan_scratch.Clear();
-
-  // noise
-  std::fill(noise.begin(), noise.end(), 0.0);
-
-  // trajectory samples
-  for (int i = 0; i < kMaxTrajectory; i++) {
-    trajectory[i].Reset(kMaxTrajectoryHorizon);
-    candidate_policy[i].Reset(horizon, initial_repeated_action);
-  }
-
-  for (const auto& d : data_) {
-    if (initial_repeated_action) {
-      mju_copy(d->ctrl, initial_repeated_action, model->nu);
-    } else {
-      mju_zero(d->ctrl, model->nu);
+    // trajectory and parameters
+    winner = -1;
+    for (int i = 0; i < kMaxTrajectory; i++)
+    {
+      trajectory[i].Initialize(num_state, model->nu, task->num_residual,
+                               task->num_trace, kMaxTrajectoryHorizon);
+      trajectory[i].Allocate(kMaxTrajectoryHorizon);
+      candidate_policy[i].Allocate(model, *task, kMaxTrajectoryHorizon);
     }
   }
 
-  // improvement
-  improvement = 0.0;
+  // reset memory to zeros
+  void SamplingPlanner::Reset(int horizon,
+                              const double *initial_repeated_action)
+  {
+    // state
+    std::fill(state.begin(), state.end(), 0.0);
+    std::fill(mocap.begin(), mocap.end(), 0.0);
+    std::fill(userdata.begin(), userdata.end(), 0.0);
+    time = 0.0;
 
-  // winner
-  winner = 0;
-}
+    // policy parameters
+    policy.Reset(horizon, initial_repeated_action);
+    previous_policy.Reset(horizon, initial_repeated_action);
 
-// set state
-void SamplingPlanner::SetState(const State& state) {
-  state.CopyTo(this->state.data(), this->mocap.data(), this->userdata.data(),
-               &this->time);
-}
+    // scratch
+    plan_scratch.Clear();
 
-int SamplingPlanner::OptimizePolicyCandidates(int ncandidates, int horizon,
-                                              ThreadPool& pool) {
-  // if num_trajectory_ has changed, use it in this new iteration.
-  // num_trajectory_ might change while this function runs. Keep it constant
-  // for the duration of this function.
-  int num_trajectory = num_trajectory_;
-  ncandidates = std::min(ncandidates, num_trajectory);
-  ResizeMjData(model, pool.NumThreads());
+    // noise
+    std::fill(noise.begin(), noise.end(), 0.0);
 
-  // ----- rollout noisy policies ----- //
-  // start timer
-  auto rollouts_start = std::chrono::steady_clock::now();
+    // trajectory samples
+    for (int i = 0; i < kMaxTrajectory; i++)
+    {
+      trajectory[i].Reset(kMaxTrajectoryHorizon);
+      candidate_policy[i].Reset(horizon, initial_repeated_action);
+    }
 
-  // simulate noisy policies
-  policy.plan.SetInterpolation(interpolation_);
-  this->Rollouts(num_trajectory, horizon, pool);
+    for (const auto &d : data_)
+    {
+      if (initial_repeated_action)
+      {
+        mju_copy(d->ctrl, initial_repeated_action, model->nu);
+      }
+      else
+      {
+        mju_zero(d->ctrl, model->nu);
+      }
+    }
 
-  // sort candidate policies and trajectories by score
-  trajectory_order.clear();
-  trajectory_order.reserve(num_trajectory);
-  for (int i = 0; i < num_trajectory; i++) {
-    trajectory_order.push_back(i);
+    // improvement
+    improvement = 0.0;
+
+    // winner
+    winner = 0;
   }
 
-  // sort so that the first ncandidates elements are the best candidates, and
-  // the rest are in an unspecified order
-  std::partial_sort(
-      trajectory_order.begin(), trajectory_order.begin() + ncandidates,
-      trajectory_order.end(), [trajectory = trajectory](int a, int b) {
-        return trajectory[a].total_return < trajectory[b].total_return;
-      });
-
-  // stop timer
-  rollouts_compute_time = GetDuration(rollouts_start);
-
-  return ncandidates;
-}
-
-// optimize nominal policy using random sampling
-void SamplingPlanner::OptimizePolicy(int horizon, ThreadPool& pool) {
-  // resample nominal policy to current time
-  this->UpdateNominalPolicy(horizon);
-
-  OptimizePolicyCandidates(1, horizon, pool);
-
-  // ----- update policy ----- //
-  // start timer
-  auto policy_update_start = std::chrono::steady_clock::now();
-
-  CopyCandidateToPolicy(0);
-
-  // improvement: compare nominal to winner
-  double best_return = trajectory[0].total_return;
-  improvement = mju_max(best_return - trajectory[winner].total_return, 0.0);
-
-  // stop timer
-  policy_update_compute_time = GetDuration(policy_update_start);
-}
-
-// compute trajectory using nominal policy
-void SamplingPlanner::NominalTrajectory(int horizon, ThreadPool& pool) {
-  // set policy
-  auto nominal_policy = [&cp = candidate_policy[0]](
-                            double* action, const double* state, double time) {
-    cp.Action(action, state, time);
-  };
-
-  // rollout nominal policy
-  trajectory[0].Rollout(nominal_policy, task, model, data_[0].get(),
-                        state.data(), time, mocap.data(), userdata.data(),
-                        horizon);
-}
-
-// set action from policy
-void SamplingPlanner::ActionFromPolicy(double* action, const double* state,
-                                       double time, bool use_previous) {
-  const std::shared_lock<std::shared_mutex> lock(mtx_);
-  if (use_previous) {
-    previous_policy.Action(action, state, time);
-  } else {
-    policy.Action(action, state, time);
+  // set state
+  void SamplingPlanner::SetState(const State &state)
+  {
+    state.CopyTo(this->state.data(), this->mocap.data(), this->userdata.data(),
+                 &this->time);
   }
-}
 
-// update policy via resampling
-void SamplingPlanner::UpdateNominalPolicy(int horizon) {
-  // dimensions
-  int num_spline_points = candidate_policy[winner].num_spline_points;
+  int SamplingPlanner::OptimizePolicyCandidates(int ncandidates, int horizon,
+                                                ThreadPool &pool)
+  {
+    // if num_trajectory_ has changed, use it in this new iteration.
+    // num_trajectory_ might change while this function runs. Keep it constant
+    // for the duration of this function.
+    int num_trajectory = num_trajectory_;
+    ncandidates = std::min(ncandidates, num_trajectory);
+    ResizeMjData(model, pool.NumThreads());
 
-  // set time
-  double nominal_time = time;
-  double time_horizon = (horizon - 1) * model->opt.timestep;
+    // ----- rollout noisy policies ----- //
+    // start timer
+    auto rollouts_start = std::chrono::steady_clock::now();
 
-  if (sliding_plan_) {
-    // extra points required outside of the horizon window
-    int extra_points;
-    switch (interpolation_) {
+    // simulate noisy policies
+    policy.plan.SetInterpolation(interpolation_);
+    this->Rollouts(num_trajectory, horizon, pool);
+
+    // sort candidate policies and trajectories by score
+    trajectory_order.clear();
+    trajectory_order.reserve(num_trajectory);
+    for (int i = 0; i < num_trajectory; i++)
+    {
+      trajectory_order.push_back(i);
+    }
+
+    // sort so that the first ncandidates elements are the best candidates, and
+    // the rest are in an unspecified order
+    std::partial_sort(
+        trajectory_order.begin(), trajectory_order.begin() + ncandidates,
+        trajectory_order.end(), [trajectory = trajectory](int a, int b)
+        { return trajectory[a].total_return < trajectory[b].total_return; });
+
+    // stop timer
+    rollouts_compute_time = GetDuration(rollouts_start);
+
+    return ncandidates;
+  }
+
+  // optimize nominal policy using random sampling
+  void SamplingPlanner::OptimizePolicy(int horizon, ThreadPool &pool)
+  {
+    // resample nominal policy to current time
+    this->UpdateNominalPolicy(horizon);
+
+    OptimizePolicyCandidates(1, horizon, pool);
+
+    // ----- update policy ----- //
+    // start timer
+    auto policy_update_start = std::chrono::steady_clock::now();
+
+    CopyCandidateToPolicy(0);
+
+    // improvement: compare nominal to winner
+    double best_return = trajectory[0].total_return;
+    improvement = mju_max(best_return - trajectory[winner].total_return, 0.0);
+
+    // stop timer
+    policy_update_compute_time = GetDuration(policy_update_start);
+  }
+
+  // compute trajectory using nominal policy
+  void SamplingPlanner::NominalTrajectory(int horizon, ThreadPool &pool)
+  {
+    // set policy
+    auto nominal_policy = [&cp = candidate_policy[0]](
+                              double *action, const double *state, double time)
+    {
+      cp.Action(action, state, time);
+    };
+
+    // rollout nominal policy
+    trajectory[0].Rollout(nominal_policy, task, model, data_[0].get(),
+                          state.data(), time, mocap.data(), userdata.data(),
+                          horizon);
+  }
+
+  // set action from policy
+  void SamplingPlanner::ActionFromPolicy(double *action, const double *state,
+                                         double time, bool use_previous)
+  {
+    const std::shared_lock<std::shared_mutex> lock(mtx_);
+    if (use_previous)
+    {
+      previous_policy.Action(action, state, time);
+    }
+    else
+    {
+      policy.Action(action, state, time);
+    }
+  }
+
+  // update policy via resampling
+  void SamplingPlanner::UpdateNominalPolicy(int horizon)
+  {
+    // dimensions
+    int num_spline_points = candidate_policy[winner].num_spline_points;
+
+    // set time
+    double nominal_time = time;
+    double time_horizon = (horizon - 1) * model->opt.timestep;
+
+    if (sliding_plan_)
+    {
+      // extra points required outside of the horizon window
+      int extra_points;
+      switch (interpolation_)
+      {
       case spline::SplineInterpolation::kZeroSpline:
         extra_points = 1;
         break;
@@ -254,103 +278,122 @@ void SamplingPlanner::UpdateNominalPolicy(int horizon) {
       case spline::SplineInterpolation::kCubicSpline:
         extra_points = 4;
         break;
-    }
+      }
 
-    // temporal distance between spline points
-    double time_shift;
-    if (num_spline_points > extra_points) {
-      time_shift = mju_max(time_horizon /
-                            (num_spline_points - extra_points), 1.0e-5);
-    } else {
-      // not a valid setting, but avoid division by zero
-      time_shift = time_horizon;
-    }
+      // temporal distance between spline points
+      double time_shift;
+      if (num_spline_points > extra_points)
+      {
+        time_shift = mju_max(time_horizon /
+                                 (num_spline_points - extra_points),
+                             1.0e-5);
+      }
+      else
+      {
+        // not a valid setting, but avoid division by zero
+        time_shift = time_horizon;
+      }
 
-    const std::shared_lock<std::shared_mutex> lock(mtx_);
-    policy.plan.DiscardBefore(nominal_time);
-    if (policy.plan.Size() == 0) {
-      policy.plan.AddNode(time);
-    }
-    while (policy.plan.Size() < num_spline_points) {
-      // duplicate the last node, with a time further in the future.
-      double new_node_time = (policy.plan.end() - 1)->time() + time_shift;
-      TimeSpline::Node new_node = policy.plan.AddNode(new_node_time);
-      std::copy((policy.plan.end() - 2)->values().begin(),
-                (policy.plan.end() - 2)->values().end(),
-                new_node.values().begin());
-    }
-  } else {
-    // non-sliding, resample the plan into a scratch plan
-    double time_shift;
-    if (interpolation_ == spline::SplineInterpolation::kZeroSpline) {
-      time_shift = mju_max(time_horizon / num_spline_points, 1.0e-5);
-    } else {
-      time_shift = mju_max(time_horizon / (num_spline_points - 1), 1.0e-5);
-    }
-
-    // resample the nominal plan on a new set of spline points
-    plan_scratch.Clear();
-    plan_scratch.SetInterpolation(interpolation_);
-    plan_scratch.Reserve(num_spline_points);
-
-    // get spline points
-    for (int t = 0; t < num_spline_points; t++) {
-      TimeSpline::Node node = plan_scratch.AddNode(nominal_time);
-      candidate_policy[winner].Action(node.values().data(), /*state=*/nullptr,
-                                      nominal_time);
-      nominal_time += time_shift;
-    }
-
-    // copy scratch into plan
-    {
       const std::shared_lock<std::shared_mutex> lock(mtx_);
-      policy.plan = plan_scratch;
+      policy.plan.DiscardBefore(nominal_time);
+      if (policy.plan.Size() == 0)
+      {
+        policy.plan.AddNode(time);
+      }
+      while (policy.plan.Size() < num_spline_points)
+      {
+        // duplicate the last node, with a time further in the future.
+        double new_node_time = (policy.plan.end() - 1)->time() + time_shift;
+        TimeSpline::Node new_node = policy.plan.AddNode(new_node_time);
+        std::copy((policy.plan.end() - 2)->values().begin(),
+                  (policy.plan.end() - 2)->values().end(),
+                  new_node.values().begin());
+      }
+    }
+    else
+    {
+      // non-sliding, resample the plan into a scratch plan
+      double time_shift;
+      if (interpolation_ == spline::SplineInterpolation::kZeroSpline)
+      {
+        time_shift = mju_max(time_horizon / num_spline_points, 1.0e-5);
+      }
+      else
+      {
+        time_shift = mju_max(time_horizon / (num_spline_points - 1), 1.0e-5);
+      }
+
+      // resample the nominal plan on a new set of spline points
+      plan_scratch.Clear();
+      plan_scratch.SetInterpolation(interpolation_);
+      plan_scratch.Reserve(num_spline_points);
+
+      // get spline points
+      for (int t = 0; t < num_spline_points; t++)
+      {
+        TimeSpline::Node node = plan_scratch.AddNode(nominal_time);
+        candidate_policy[winner].Action(node.values().data(), /*state=*/nullptr,
+                                        nominal_time);
+        nominal_time += time_shift;
+      }
+
+      // copy scratch into plan
+      {
+        const std::shared_lock<std::shared_mutex> lock(mtx_);
+        policy.plan = plan_scratch;
+      }
     }
   }
-}
 
-// add random noise to nominal policy
-void SamplingPlanner::AddNoiseToPolicy(double start_time, int i) {
-  // start timer
-  auto noise_start = std::chrono::steady_clock::now();
+  // add random noise to nominal policy
+  void SamplingPlanner::AddNoiseToPolicy(double start_time, int i)
+  {
+    // start timer
+    auto noise_start = std::chrono::steady_clock::now();
 
-  // sampling token
-  absl::BitGen gen_;
+    // sampling token
+    absl::BitGen gen_;
 
-  // get standard deviation, fixed or mixture of noise_exploration[0,1]
-  double std = noise_exploration[0];
-  constexpr double kStd2Proportion = 0.2;  // hardcoded proportion of 2nd std
-  if (noise_exploration[1] > 0 && absl::Bernoulli(gen_, kStd2Proportion)) {
-    std = noise_exploration[1];
-  }
-
-  for (const TimeSpline::Node& node : candidate_policy[i].plan) {
-    for (int k = 0; k < model->nu; k++) {
-      double scale = 0.5 * (model->actuator_ctrlrange[2 * k + 1] -
-                            model->actuator_ctrlrange[2 * k]);
-      double noise = absl::Gaussian<double>(gen_, 0.0, scale * std);
-      node.values()[k] += noise;
+    // get standard deviation, fixed or mixture of noise_exploration[0,1]
+    double std = noise_exploration[0];
+    constexpr double kStd2Proportion = 0.2; // hardcoded proportion of 2nd std
+    if (noise_exploration[1] > 0 && absl::Bernoulli(gen_, kStd2Proportion))
+    {
+      std = noise_exploration[1];
     }
-    Clamp(node.values().data(), model->actuator_ctrlrange, model->nu);
+
+    for (const TimeSpline::Node &node : candidate_policy[i].plan)
+    {
+      for (int k = 0; k < model->nu; k++)
+      {
+        double scale = 0.5 * (model->actuator_ctrlrange[2 * k + 1] -
+                              model->actuator_ctrlrange[2 * k]);
+        double noise = absl::Gaussian<double>(gen_, 0.0, scale * std);
+        node.values()[k] += noise;
+      }
+      Clamp(node.values().data(), model->actuator_ctrlrange, model->nu);
+    }
+
+    // end timer
+    IncrementAtomic(noise_compute_time, GetDuration(noise_start));
   }
 
-  // end timer
-  IncrementAtomic(noise_compute_time, GetDuration(noise_start));
-}
+  // compute candidate trajectories
+  void SamplingPlanner::Rollouts(int num_trajectory, int horizon,
+                                 ThreadPool &pool)
+  {
+    // reset noise compute time
+    noise_compute_time = 0.0;
 
-// compute candidate trajectories
-void SamplingPlanner::Rollouts(int num_trajectory, int horizon,
-                               ThreadPool& pool) {
-  // reset noise compute time
-  noise_compute_time = 0.0;
-
-  // random search
-  int count_before = pool.GetCount();
-  for (int i = 0; i < num_trajectory; i++) {
-    pool.Schedule([&s = *this, &model = this->model, &task = this->task,
-                   &state = this->state, &time = this->time,
-                   &mocap = this->mocap, &userdata = this->userdata, horizon,
-                   i]() {
+    // random search
+    int count_before = pool.GetCount();
+    for (int i = 0; i < num_trajectory; i++)
+    {
+      pool.Schedule([&s = *this, &model = this->model, &task = this->task,
+                     &state = this->state, &time = this->time,
+                     &mocap = this->mocap, &userdata = this->userdata, horizon,
+                     i]()
+                    {
       // copy nominal policy
       {
         const std::shared_lock<std::shared_mutex> lock(s.mtx_);
@@ -372,164 +415,181 @@ void SamplingPlanner::Rollouts(int num_trajectory, int horizon,
       // policy rollout
       s.trajectory[i].Rollout(
           sample_policy_i, task, model, s.data_[ThreadPool::WorkerId()].get(),
-          state.data(), time, mocap.data(), userdata.data(), horizon);
-    });
+          state.data(), time, mocap.data(), userdata.data(), horizon); });
+    }
+    pool.WaitCount(count_before + num_trajectory);
+    pool.ResetCount();
   }
-  pool.WaitCount(count_before + num_trajectory);
-  pool.ResetCount();
-}
 
-// return trajectory with best total return
-const Trajectory* SamplingPlanner::BestTrajectory() {
-  return winner >= 0 ? &trajectory[winner] : nullptr;
-}
+  void SamplingPlanner::Parameters(double *parameters)
+  {
+    const std::shared_lock<std::shared_mutex> lock(mtx_);
+    policy.Parameters(parameters);
+  }
 
-// visualize planner-specific traces
-void SamplingPlanner::Traces(mjvScene* scn) {
-  // sample color
-  float color[4];
-  color[0] = 1.0;
-  color[1] = 1.0;
-  color[2] = 1.0;
-  color[3] = 1.0;
+  // return trajectory with best total return
+  const Trajectory *SamplingPlanner::BestTrajectory()
+  {
+    return winner >= 0 ? &trajectory[winner] : nullptr;
+  }
 
-  // width of a sample trace, in pixels
-  double width = GetNumberOrDefault(3, model, "agent_sample_width");
+  // visualize planner-specific traces
+  void SamplingPlanner::Traces(mjvScene *scn)
+  {
+    // sample color
+    float color[4];
+    color[0] = 1.0;
+    color[1] = 1.0;
+    color[2] = 1.0;
+    color[3] = 1.0;
 
-  // scratch
-  double zero3[3] = {0};
-  double zero9[9] = {0};
+    // width of a sample trace, in pixels
+    double width = GetNumberOrDefault(3, model, "agent_sample_width");
 
-  // best
-  auto best = this->BestTrajectory();
+    // scratch
+    double zero3[3] = {0};
+    double zero9[9] = {0};
 
-  // sample traces
-  for (int k = 0; k < num_trajectory_; k++) {
-    // skip winner
-    if (k == winner) continue;
+    // best
+    auto best = this->BestTrajectory();
 
-    // plot sample
-    for (int i = 0; i < best->horizon - 1; i++) {
-      if (scn->ngeom + task->num_trace > scn->maxgeom) break;
-      for (int j = 0; j < task->num_trace; j++) {
-        // initialize geometry
-        mjv_initGeom(&scn->geoms[scn->ngeom], mjGEOM_LINE, zero3, zero3, zero9,
-                     color);
+    // sample traces
+    for (int k = 0; k < num_trajectory_; k++)
+    {
+      // skip winner
+      if (k == winner)
+        continue;
 
-        // make geometry
-        mjv_makeConnector(
-            &scn->geoms[scn->ngeom], mjGEOM_LINE, width,
-            trajectory[k].trace[3 * task->num_trace * i + 3 * j],
-            trajectory[k].trace[3 * task->num_trace * i + 1 + 3 * j],
-            trajectory[k].trace[3 * task->num_trace * i + 2 + 3 * j],
-            trajectory[k].trace[3 * task->num_trace * (i + 1) + 3 * j],
-            trajectory[k].trace[3 * task->num_trace * (i + 1) + 1 + 3 * j],
-            trajectory[k].trace[3 * task->num_trace * (i + 1) + 2 + 3 * j]);
+      // plot sample
+      for (int i = 0; i < best->horizon - 1; i++)
+      {
+        if (scn->ngeom + task->num_trace > scn->maxgeom)
+          break;
+        for (int j = 0; j < task->num_trace; j++)
+        {
+          // initialize geometry
+          mjv_initGeom(&scn->geoms[scn->ngeom], mjGEOM_LINE, zero3, zero3, zero9,
+                       color);
 
-        // increment number of geometries
-        scn->ngeom += 1;
+          // make geometry
+          mjv_makeConnector(
+              &scn->geoms[scn->ngeom], mjGEOM_LINE, width,
+              trajectory[k].trace[3 * task->num_trace * i + 3 * j],
+              trajectory[k].trace[3 * task->num_trace * i + 1 + 3 * j],
+              trajectory[k].trace[3 * task->num_trace * i + 2 + 3 * j],
+              trajectory[k].trace[3 * task->num_trace * (i + 1) + 3 * j],
+              trajectory[k].trace[3 * task->num_trace * (i + 1) + 1 + 3 * j],
+              trajectory[k].trace[3 * task->num_trace * (i + 1) + 2 + 3 * j]);
+
+          // increment number of geometries
+          scn->ngeom += 1;
+        }
       }
     }
   }
-}
 
-// planner-specific GUI elements
-void SamplingPlanner::GUI(mjUI& ui) {
-  mjuiDef defSampling[] = {
-      {mjITEM_SLIDERINT, "Rollouts", 2, &num_trajectory_, "0 1"},
-      {mjITEM_SELECT, "Spline", 2, &interpolation_,
-       "Zero\nLinear\nCubic"},
-      {mjITEM_SLIDERINT, "Spline Pts", 2, &policy.num_spline_points, "0 1"},
-      {mjITEM_SLIDERNUM, "Noise Std", 2, noise_exploration, "0 1"},
-      {mjITEM_SLIDERNUM, "Noise Std2", 2, noise_exploration+1, "0 1"},
-      {mjITEM_CHECKBYTE, "Sliding plan", 2, &sliding_plan_, ""},
-      {mjITEM_END}};
-
-  // set number of trajectory slider limits
-  mju::sprintf_arr(defSampling[0].other, "%i %i", 1, kMaxTrajectory);
-
-  // set spline point limits
-  mju::sprintf_arr(defSampling[2].other, "%i %i", MinSamplingSplinePoints,
-                   MaxSamplingSplinePoints);
-
-  // set noise standard deviation limits
-  mju::sprintf_arr(defSampling[3].other, "%f %f", MinNoiseStdDev,
-                   MaxNoiseStdDev);
-
-  // add sampling planner
-  mjui_add(&ui, defSampling);
-}
-
-// planner-specific plots
-void SamplingPlanner::Plots(mjvFigure* fig_planner, mjvFigure* fig_timer,
-                            int planner_shift, int timer_shift, int planning,
-                            int* shift) {
-  // ----- planner ----- //
-  double planner_bounds[2] = {-6.0, 6.0};
-
-  // improvement
-  mjpc::PlotUpdateData(fig_planner, planner_bounds,
-                       fig_planner->linedata[0 + planner_shift][0] + 1,
-                       mju_log10(mju_max(improvement, 1.0e-6)), 100,
-                       0 + planner_shift, 0, 1, -100);
-
-  // legend
-  mju::strcpy_arr(fig_planner->linename[0 + planner_shift], "Improvement");
-
-  fig_planner->range[1][0] = planner_bounds[0];
-  fig_planner->range[1][1] = planner_bounds[1];
-
-  // bounds
-  double timer_bounds[2] = {0.0, 1.0};
-
-  // ----- timer ----- //
-
-  PlotUpdateData(fig_timer, timer_bounds,
-                 fig_timer->linedata[0 + timer_shift][0] + 1,
-                 1.0e-3 * noise_compute_time * planning, 100,
-                 0 + timer_shift, 0, 1, -100);
-
-  PlotUpdateData(fig_timer, timer_bounds,
-                 fig_timer->linedata[1 + timer_shift][0] + 1,
-                 1.0e-3 * rollouts_compute_time * planning, 100,
-                 1 + timer_shift, 0, 1, -100);
-
-  PlotUpdateData(fig_timer, timer_bounds,
-                 fig_timer->linedata[2 + timer_shift][0] + 1,
-                 1.0e-3 * policy_update_compute_time * planning, 100,
-                 2 + timer_shift, 0, 1, -100);
-
-  // legend
-  mju::strcpy_arr(fig_timer->linename[0 + timer_shift], "Noise");
-  mju::strcpy_arr(fig_timer->linename[1 + timer_shift], "Rollout");
-  mju::strcpy_arr(fig_timer->linename[2 + timer_shift], "Policy Update");
-
-  // planner shift
-  shift[0] += 1;
-
-  // timer shift
-  shift[1] += 3;
-}
-
-double SamplingPlanner::CandidateScore(int candidate) const {
-  return trajectory[trajectory_order[candidate]].total_return;
-}
-
-// set action from candidate policy
-void SamplingPlanner::ActionFromCandidatePolicy(double* action, int candidate,
-                                                const double* state,
-                                                double time) {
-  candidate_policy[trajectory_order[candidate]].Action(action, state, time);
-}
-
-void SamplingPlanner::CopyCandidateToPolicy(int candidate) {
-  // set winner
-  winner = trajectory_order[candidate];
-
+  // planner-specific GUI elements
+  void SamplingPlanner::GUI(mjUI &ui)
   {
-    const std::shared_lock<std::shared_mutex> lock(mtx_);
-    previous_policy = policy;
-    policy = candidate_policy[winner];
+    mjuiDef defSampling[] = {
+        {mjITEM_SLIDERINT, "Rollouts", 2, &num_trajectory_, "0 1"},
+        {mjITEM_SELECT, "Spline", 2, &interpolation_,
+         "Zero\nLinear\nCubic"},
+        {mjITEM_SLIDERINT, "Spline Pts", 2, &policy.num_spline_points, "0 1"},
+        {mjITEM_SLIDERNUM, "Noise Std", 2, noise_exploration, "0 1"},
+        {mjITEM_SLIDERNUM, "Noise Std2", 2, noise_exploration + 1, "0 1"},
+        {mjITEM_CHECKBYTE, "Sliding plan", 2, &sliding_plan_, ""},
+        {mjITEM_END}};
+
+    // set number of trajectory slider limits
+    mju::sprintf_arr(defSampling[0].other, "%i %i", 1, kMaxTrajectory);
+
+    // set spline point limits
+    mju::sprintf_arr(defSampling[2].other, "%i %i", MinSamplingSplinePoints,
+                     MaxSamplingSplinePoints);
+
+    // set noise standard deviation limits
+    mju::sprintf_arr(defSampling[3].other, "%f %f", MinNoiseStdDev,
+                     MaxNoiseStdDev);
+
+    // add sampling planner
+    mjui_add(&ui, defSampling);
   }
-}
-}  // namespace mjpc
+
+  // planner-specific plots
+  void SamplingPlanner::Plots(mjvFigure *fig_planner, mjvFigure *fig_timer,
+                              int planner_shift, int timer_shift, int planning,
+                              int *shift)
+  {
+    // ----- planner ----- //
+    double planner_bounds[2] = {-6.0, 6.0};
+
+    // improvement
+    mjpc::PlotUpdateData(fig_planner, planner_bounds,
+                         fig_planner->linedata[0 + planner_shift][0] + 1,
+                         mju_log10(mju_max(improvement, 1.0e-6)), 100,
+                         0 + planner_shift, 0, 1, -100);
+
+    // legend
+    mju::strcpy_arr(fig_planner->linename[0 + planner_shift], "Improvement");
+
+    fig_planner->range[1][0] = planner_bounds[0];
+    fig_planner->range[1][1] = planner_bounds[1];
+
+    // bounds
+    double timer_bounds[2] = {0.0, 1.0};
+
+    // ----- timer ----- //
+
+    PlotUpdateData(fig_timer, timer_bounds,
+                   fig_timer->linedata[0 + timer_shift][0] + 1,
+                   1.0e-3 * noise_compute_time * planning, 100,
+                   0 + timer_shift, 0, 1, -100);
+
+    PlotUpdateData(fig_timer, timer_bounds,
+                   fig_timer->linedata[1 + timer_shift][0] + 1,
+                   1.0e-3 * rollouts_compute_time * planning, 100,
+                   1 + timer_shift, 0, 1, -100);
+
+    PlotUpdateData(fig_timer, timer_bounds,
+                   fig_timer->linedata[2 + timer_shift][0] + 1,
+                   1.0e-3 * policy_update_compute_time * planning, 100,
+                   2 + timer_shift, 0, 1, -100);
+
+    // legend
+    mju::strcpy_arr(fig_timer->linename[0 + timer_shift], "Noise");
+    mju::strcpy_arr(fig_timer->linename[1 + timer_shift], "Rollout");
+    mju::strcpy_arr(fig_timer->linename[2 + timer_shift], "Policy Update");
+
+    // planner shift
+    shift[0] += 1;
+
+    // timer shift
+    shift[1] += 3;
+  }
+
+  double SamplingPlanner::CandidateScore(int candidate) const
+  {
+    return trajectory[trajectory_order[candidate]].total_return;
+  }
+
+  // set action from candidate policy
+  void SamplingPlanner::ActionFromCandidatePolicy(double *action, int candidate,
+                                                  const double *state,
+                                                  double time)
+  {
+    candidate_policy[trajectory_order[candidate]].Action(action, state, time);
+  }
+
+  void SamplingPlanner::CopyCandidateToPolicy(int candidate)
+  {
+    // set winner
+    winner = trajectory_order[candidate];
+
+    {
+      const std::shared_lock<std::shared_mutex> lock(mtx_);
+      previous_policy = policy;
+      policy = candidate_policy[winner];
+    }
+  }
+} // namespace mjpc

--- a/mjpc/planners/sampling/planner.h
+++ b/mjpc/planners/sampling/planner.h
@@ -91,7 +91,7 @@ namespace mjpc
     void GUI(mjUI &ui) override;
 
     // return sampling policy parameters.
-    void Parameters(double *parameters);
+    void Parameters(double *parameters) override;
 
     // planner-specific plots
     void Plots(mjvFigure *fig_planner, mjvFigure *fig_timer, int planner_shift,

--- a/mjpc/planners/sampling/planner.h
+++ b/mjpc/planners/sampling/planner.h
@@ -29,139 +29,145 @@
 #include "mjpc/task.h"
 #include "mjpc/trajectory.h"
 
-namespace mjpc {
+namespace mjpc
+{
 
-// sampling planner limits
-inline constexpr int MinSamplingSplinePoints = 1;
-inline constexpr int MaxSamplingSplinePoints = 36;
-inline constexpr double MinNoiseStdDev = 0.0;
-inline constexpr double MaxNoiseStdDev = 1.0;
+  // sampling planner limits
+  inline constexpr int MinSamplingSplinePoints = 1;
+  inline constexpr int MaxSamplingSplinePoints = 36;
+  inline constexpr double MinNoiseStdDev = 0.0;
+  inline constexpr double MaxNoiseStdDev = 1.0;
 
-class SamplingPlanner : public RankedPlanner {
- public:
-  // constructor
-  SamplingPlanner() = default;
+  class SamplingPlanner : public RankedPlanner
+  {
+  public:
+    // constructor
+    SamplingPlanner() = default;
 
-  // destructor
-  ~SamplingPlanner() override = default;
+    // destructor
+    ~SamplingPlanner() override = default;
 
-  // ----- methods ----- //
+    // ----- methods ----- //
 
-  // initialize data and settings
-  void Initialize(mjModel* model, const Task& task) override;
+    // initialize data and settings
+    void Initialize(mjModel *model, const Task &task) override;
 
-  // allocate memory
-  void Allocate() override;
+    // allocate memory
+    void Allocate() override;
 
-  // reset memory to zeros
-  void Reset(int horizon,
-             const double* initial_repeated_action = nullptr) override;
+    // reset memory to zeros
+    void Reset(int horizon,
+               const double *initial_repeated_action = nullptr) override;
 
-  // set state
-  void SetState(const State& state) override;
+    // set state
+    void SetState(const State &state) override;
 
-  // optimize nominal policy using random sampling
-  void OptimizePolicy(int horizon, ThreadPool& pool) override;
+    // optimize nominal policy using random sampling
+    void OptimizePolicy(int horizon, ThreadPool &pool) override;
 
-  // compute trajectory using nominal policy
-  void NominalTrajectory(int horizon, ThreadPool& pool) override;
+    // compute trajectory using nominal policy
+    void NominalTrajectory(int horizon, ThreadPool &pool) override;
 
-  // set action from policy
-  void ActionFromPolicy(double* action, const double* state,
-                        double time, bool use_previous = false) override;
+    // set action from policy
+    void ActionFromPolicy(double *action, const double *state,
+                          double time, bool use_previous = false) override;
 
-  // resample nominal policy
-  void UpdateNominalPolicy(int horizon);
+    // resample nominal policy
+    void UpdateNominalPolicy(int horizon);
 
-  // add noise to nominal policy
-  void AddNoiseToPolicy(double start_time, int i);
+    // add noise to nominal policy
+    void AddNoiseToPolicy(double start_time, int i);
 
-  // compute candidate trajectories
-  void Rollouts(int num_trajectory, int horizon, ThreadPool& pool);
+    // compute candidate trajectories
+    void Rollouts(int num_trajectory, int horizon, ThreadPool &pool);
 
-  // return trajectory with best total return
-  const Trajectory* BestTrajectory() override;
+    // return trajectory with best total return
+    const Trajectory *BestTrajectory() override;
 
-  // visualize planner-specific traces
-  void Traces(mjvScene* scn) override;
+    // visualize planner-specific traces
+    void Traces(mjvScene *scn) override;
 
-  // planner-specific GUI elements
-  void GUI(mjUI& ui) override;
+    // planner-specific GUI elements
+    void GUI(mjUI &ui) override;
 
-  // planner-specific plots
-  void Plots(mjvFigure* fig_planner, mjvFigure* fig_timer, int planner_shift,
-             int timer_shift, int planning, int* shift) override;
+    // return sampling policy parameters.
+    void Parameters(double *parameters);
 
-  // return number of parameters optimized by planner
-  int NumParameters() override {
-    return policy.num_spline_points * model->nu;
+    // planner-specific plots
+    void Plots(mjvFigure *fig_planner, mjvFigure *fig_timer, int planner_shift,
+               int timer_shift, int planning, int *shift) override;
+
+    // return number of parameters optimized by planner
+    int NumParameters() override
+    {
+      return policy.num_spline_points * model->nu;
+    };
+
+    // optimizes policies, but rather than picking the best, generate up to
+    // ncandidates. returns number of candidates created.
+    int OptimizePolicyCandidates(int ncandidates, int horizon,
+                                 ThreadPool &pool) override;
+    // returns the total return for the nth candidate (or another score to
+    // minimize)
+    double CandidateScore(int candidate) const override;
+
+    // set action from candidate policy
+    void ActionFromCandidatePolicy(double *action, int candidate,
+                                   const double *state, double time) override;
+
+    void CopyCandidateToPolicy(int candidate) override;
+
+    // ----- members ----- //
+    mjModel *model;
+    const Task *task;
+
+    // state
+    std::vector<double> state;
+    double time;
+    std::vector<double> mocap;
+    std::vector<double> userdata;
+
+    // policy
+    SamplingPolicy policy; // (Guarded by mtx_)
+    SamplingPolicy candidate_policy[kMaxTrajectory];
+    SamplingPolicy previous_policy;
+
+    // scratch
+    mjpc::spline::TimeSpline plan_scratch;
+
+    // trajectories
+    Trajectory trajectory[kMaxTrajectory];
+
+    // order of indices of rolled out trajectories, ordered by total return
+    std::vector<int> trajectory_order;
+
+    // ----- noise ----- //
+    double noise_exploration[2] = {0}; // stds for sampling: N(0, exploration)
+    std::vector<double> noise;
+    mjpc::spline::SplineInterpolation interpolation_ =
+        mjpc::spline::SplineInterpolation::kZeroSpline;
+
+    // best trajectory
+    int winner;
+
+    // improvement
+    double improvement;
+
+    // flags
+    int processed_noise_status;
+
+    // timing
+    std::atomic<double> noise_compute_time;
+    double rollouts_compute_time;
+    double policy_update_compute_time;
+
+    // If true, use sliding plans (no resampling)
+    std::uint8_t sliding_plan_ = false;
+
+    int num_trajectory_;
+    mutable std::shared_mutex mtx_;
   };
 
-  // optimizes policies, but rather than picking the best, generate up to
-  // ncandidates. returns number of candidates created.
-  int OptimizePolicyCandidates(int ncandidates, int horizon,
-                               ThreadPool& pool) override;
-  // returns the total return for the nth candidate (or another score to
-  // minimize)
-  double CandidateScore(int candidate) const override;
+} // namespace mjpc
 
-  // set action from candidate policy
-  void ActionFromCandidatePolicy(double* action, int candidate,
-                                 const double* state, double time) override;
-
-  void CopyCandidateToPolicy(int candidate) override;
-
-  // ----- members ----- //
-  mjModel* model;
-  const Task* task;
-
-  // state
-  std::vector<double> state;
-  double time;
-  std::vector<double> mocap;
-  std::vector<double> userdata;
-
-  // policy
-  SamplingPolicy policy;  // (Guarded by mtx_)
-  SamplingPolicy candidate_policy[kMaxTrajectory];
-  SamplingPolicy previous_policy;
-
-  // scratch
-  mjpc::spline::TimeSpline plan_scratch;
-
-  // trajectories
-  Trajectory trajectory[kMaxTrajectory];
-
-  // order of indices of rolled out trajectories, ordered by total return
-  std::vector<int> trajectory_order;
-
-  // ----- noise ----- //
-  double noise_exploration[2] = {0};  // stds for sampling: N(0, exploration)
-  std::vector<double> noise;
-mjpc::spline::SplineInterpolation interpolation_ =
-      mjpc::spline::SplineInterpolation::kZeroSpline;
-
-  // best trajectory
-  int winner;
-
-  // improvement
-  double improvement;
-
-  // flags
-  int processed_noise_status;
-
-  // timing
-  std::atomic<double> noise_compute_time;
-  double rollouts_compute_time;
-  double policy_update_compute_time;
-
-  // If true, use sliding plans (no resampling)
-  std::uint8_t sliding_plan_ = false;
-
-  int num_trajectory_;
-  mutable std::shared_mutex mtx_;
-};
-
-}  // namespace mjpc
-
-#endif  // MJPC_PLANNERS_SAMPLING_PLANNER_H_
+#endif // MJPC_PLANNERS_SAMPLING_PLANNER_H_

--- a/mjpc/planners/sampling/policy.cc
+++ b/mjpc/planners/sampling/policy.cc
@@ -54,15 +54,6 @@ namespace mjpc
         parameters[i * plan.Dim() + j] = node.values()[j];
       }
     }
-    // std::vector<double> parameters;
-    // for (int i = 0; i < num_spline_points; ++i)
-    // {
-    //   auto node = plan.NodeAt(i);
-    //   for (int j = 0; j < plan.Dim(); ++j)
-    //   {
-    //     parameters.push_back(node.values()[j]);
-    //   }
-    // }
   }
 
   // reset memory to zeros

--- a/mjpc/planners/sampling/policy.h
+++ b/mjpc/planners/sampling/policy.h
@@ -20,41 +20,46 @@
 #include "mjpc/spline/spline.h"
 #include "mjpc/task.h"
 
-namespace mjpc {
+namespace mjpc
+{
 
-// policy for sampling planner
-class SamplingPolicy : public Policy {
- public:
-  // constructor
-  SamplingPolicy() = default;
+  // policy for sampling planner
+  class SamplingPolicy : public Policy
+  {
+  public:
+    // constructor
+    SamplingPolicy() = default;
 
-  // destructor
-  ~SamplingPolicy() override = default;
+    // destructor
+    ~SamplingPolicy() override = default;
 
-  // ----- methods ----- //
+    // ----- methods ----- //
 
-  // allocate memory
-  void Allocate(const mjModel* model, const Task& task, int horizon) override;
+    // allocate memory
+    void Allocate(const mjModel *model, const Task &task, int horizon) override;
 
-  // reset memory to zeros
-  void Reset(int horizon,
-             const double* initial_repeated_action = nullptr) override;
+    // reset memory to zeros
+    void Reset(int horizon,
+               const double *initial_repeated_action = nullptr) override;
 
-  // set action from policy
-  void Action(double* action, const double* state, double time) const override;
+    // set action from policy
+    void Action(double *action, const double *state, double time) const override;
 
-  // copy policy
-  void CopyFrom(const SamplingPolicy& policy, int horizon);
+    // copy policy
+    void CopyFrom(const SamplingPolicy &policy, int horizon);
 
-  // copy parameters
-  void SetPlan(const mjpc::spline::TimeSpline& plan);
+    // copy parameters
+    void SetPlan(const mjpc::spline::TimeSpline &plan);
 
-  // ----- members ----- //
-  const mjModel* model;
-  mjpc::spline::TimeSpline plan;
-  int num_spline_points;
-};
+    // return sampling policy spline parameters
+    void Parameters(double *parameters) const;
 
-}  // namespace mjpc
+    // ----- members ----- //
+    const mjModel *model;
+    mjpc::spline::TimeSpline plan;
+    int num_spline_points;
+  };
 
-#endif  // MJPC_PLANNERS_SAMPLING_POLICY_H_
+} // namespace mjpc
+
+#endif // MJPC_PLANNERS_SAMPLING_POLICY_H_

--- a/mjpc/planners/sampling/policy.h
+++ b/mjpc/planners/sampling/policy.h
@@ -52,7 +52,7 @@ namespace mjpc
     void SetPlan(const mjpc::spline::TimeSpline &plan);
 
     // return sampling policy spline parameters
-    void Parameters(double *parameters) const;
+    void Parameters(double *parameters) const override;
 
     // ----- members ----- //
     const mjModel *model;

--- a/mjpc/tasks/cartpole/task.xml
+++ b/mjpc/tasks/cartpole/task.xml
@@ -7,7 +7,7 @@
 
   <custom>
     <!-- agent -->
-    <numeric name="agent_planner" data="1" />
+    <numeric name="agent_planner" data="5" />
     <numeric name="agent_horizon" data="1.0" />
     <numeric name="agent_timestep" data="0.01" />
     <numeric name="sampling_sample_width" data="0.01" />

--- a/python/mujoco_mpc/agent.py
+++ b/python/mujoco_mpc/agent.py
@@ -36,357 +36,338 @@ from mujoco_mpc.proto import agent_pb2_grpc
 
 
 def find_free_port() -> int:
-  """Find an available TCP port on the system.
+    """Find an available TCP port on the system.
 
-    This function creates a temporary socket, binds it to an available port
-    chosen by the operating system, and returns the chosen port number.
+      This function creates a temporary socket, binds it to an available port
+      chosen by the operating system, and returns the chosen port number.
 
-  Returns:
-      int: An available TCP port number.
-  """
-  with socket.socket(family=socket.AF_INET6) as s:
-    s.bind(("", 0))
-    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    return s.getsockname()[1]
+    Returns:
+        int: An available TCP port number.
+    """
+    with socket.socket(family=socket.AF_INET6) as s:
+        s.bind(("", 0))
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        return s.getsockname()[1]
 
 
 def parse_port(server_addr: str) -> int:
-  """Parse a port from a string.
+    """Parse a port from a string.
 
-  Args:
-    server_addr: server address
+    Args:
+      server_addr: server address
 
-  Returns:
-    int: the port
-  """
-  match = re.search(r":(\d+)", server_addr)
-  if match is None:
-    raise ValueError(f"Port not specified in server address: '{server_addr}'")
-  return int(match.group(1))
+    Returns:
+      int: the port
+    """
+    match = re.search(r":(\d+)", server_addr)
+    if match is None:
+        raise ValueError(f"Port not specified in server address: '{server_addr}'")
+    return int(match.group(1))
 
 
 class Agent(contextlib.AbstractContextManager):
-  """`Agent` class to interface with MuJoCo MPC agents.
+    """`Agent` class to interface with MuJoCo MPC agents.
 
-  Attributes:
-    task_id:
-    model:
-    port:
-    channel:
-    stub:
-    server_process:
-    server_addr:
-  """
-
-  def __init__(
-      self,
-      task_id: str,
-      model: Optional[mujoco.MjModel] = None,
-      server_binary_path: Optional[str] = None,
-      extra_flags: Sequence[str] = (),
-      real_time_speed: float = 1.0,
-      subprocess_kwargs: Optional[Mapping[str, Any]] = None,
-      connect_to: Optional[str] = None,
-      run_init: bool = True,
-  ):
-    self.task_id = task_id
-    self.model = model
-    self.port = (
-        find_free_port() if connect_to is None else parse_port(connect_to)
-    )
-
-    if server_binary_path is None:
-      binary_name = "agent_server"
-      server_binary_path = pathlib.Path(__file__).parent / "mjpc" / binary_name
-
-    self.server_process = None
-    if connect_to is None:
-      self.server_process = subprocess.Popen(
-          [str(server_binary_path), f"--mjpc_port={self.port}"]
-          + list(extra_flags),
-          **(subprocess_kwargs or {}),
-      )
-      atexit.register(self.server_process.kill)
-
-    self.server_addr = connect_to or f"localhost:{self.port}"
-    credentials = grpc.local_channel_credentials(grpc.LocalConnectionType.LOCAL_TCP)
-    self.channel = grpc.secure_channel(self.server_addr, credentials)
-    grpc.channel_ready_future(self.channel).result(timeout=30)
-    self.stub = agent_pb2_grpc.AgentStub(self.channel)
-
-    if run_init:
-      self.init(
-          task_id,
-          model,
-          send_as="mjb",
-          real_time_speed=real_time_speed,
-      )
-
-  def __exit__(self, exc_type, exc_value, traceback):
-    self.close()
-
-  def close(self):
-    self.channel.close()
-
-    if self.server_process is not None:
-      self.server_process.kill()
-      self.server_process.wait()
-
-  def init(
-      self,
-      task_id: str,
-      model: Optional[mujoco.MjModel] = None,
-      send_as: Literal["mjb", "xml"] = "xml",
-      real_time_speed: float = 1.0,
-  ):
-    """Initialize the agent for task `task_id`.
-
-    Args:
-      task_id: the identifier for the MuJoCo MPC task, for example "Cartpole" or
-        "Humanoid Track".
-      model: optional `MjModel` instance, which, if provided, will be used as
-        the underlying model for planning. If not provided, the default MJPC
-        task xml will be used.
-      send_as: The serialization format for sending the model over gRPC. Either
-        "mjb" or "xml".
-      real_time_speed: ratio of running speed to wall clock, from 0 to 1. Only
-        affects async (UI) binaries, and not ones where planning is
-        synchronous.
+    Attributes:
+      task_id:
+      model:
+      port:
+      channel:
+      stub:
+      server_process:
+      server_addr:
     """
 
-    def model_to_mjb(model: mujoco.MjModel) -> bytes:
-      buffer_size = mujoco.mj_sizeModel(model)
-      buffer = np.empty(shape=buffer_size, dtype=np.uint8)
-      mujoco.mj_saveModel(model, None, buffer)
-      return buffer.tobytes()
+    def __init__(
+        self,
+        task_id: str,
+        model: Optional[mujoco.MjModel] = None,
+        server_binary_path: Optional[str] = None,
+        extra_flags: Sequence[str] = (),
+        real_time_speed: float = 1.0,
+        subprocess_kwargs: Optional[Mapping[str, Any]] = None,
+        connect_to: Optional[str] = None,
+        run_init: bool = True,
+    ):
+        self.task_id = task_id
+        self.model = model
+        self.port = find_free_port() if connect_to is None else parse_port(connect_to)
 
-    def model_to_xml(model: mujoco.MjModel) -> str:
-      tmp = tempfile.NamedTemporaryFile()
-      mujoco.mj_saveLastXML(tmp.name, model)
-      with pathlib.Path(tmp.name).open("rt") as f:
-        xml_string = f.read()
-      return xml_string
+        if server_binary_path is None:
+            binary_name = "agent_server"
+            server_binary_path = pathlib.Path(__file__).parent / "mjpc" / binary_name
 
-    if model is not None:
-      if send_as == "mjb":
-        model_message = agent_pb2.MjModel(mjb=model_to_mjb(model))
-      else:
-        model_message = agent_pb2.MjModel(xml=model_to_xml(model))
-    else:
-      model_message = None
+        self.server_process = None
+        if connect_to is None:
+            self.server_process = subprocess.Popen(
+                [str(server_binary_path), f"--mjpc_port={self.port}"] + list(extra_flags),
+                **(subprocess_kwargs or {}),
+            )
+            atexit.register(self.server_process.kill)
 
-    init_request = agent_pb2.InitRequest(
-        task_id=task_id, model=model_message, real_time_speed=real_time_speed
-    )
-    self.stub.Init(init_request)
+        self.server_addr = connect_to or f"localhost:{self.port}"
+        credentials = grpc.local_channel_credentials(grpc.LocalConnectionType.LOCAL_TCP)
+        self.channel = grpc.secure_channel(self.server_addr, credentials)
+        grpc.channel_ready_future(self.channel).result(timeout=30)
+        self.stub = agent_pb2_grpc.AgentStub(self.channel)
 
-  def set_state(
-      self,
-      time: Optional[float] = None,
-      qpos: Optional[npt.ArrayLike] = None,
-      qvel: Optional[npt.ArrayLike] = None,
-      act: Optional[npt.ArrayLike] = None,
-      mocap_pos: Optional[npt.ArrayLike] = None,
-      mocap_quat: Optional[npt.ArrayLike] = None,
-      userdata: Optional[npt.ArrayLike] = None,
-  ):
-    """Set `Agent`'s MuJoCo `data` state.
+        if run_init:
+            self.init(
+                task_id,
+                model,
+                send_as="mjb",
+                real_time_speed=real_time_speed,
+            )
 
-    Args:
-      time: `data.time`, i.e. the simulation time.
-      qpos: `data.qpos`.
-      qvel: `data.qvel`.
-      act: `data.act`.
-      mocap_pos: `data.mocap_pos`.
-      mocap_quat: `data.mocap_quat`.
-      userdata: `data.userdata`.
-    """
-    # if mocap_pos is an ndarray rather than a list, flatten it
-    if hasattr(mocap_pos, "flatten"):
-      mocap_pos = mocap_pos.flatten()
-    if hasattr(mocap_quat, "flatten"):
-      mocap_quat = mocap_quat.flatten()
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
 
-    state = agent_pb2.State(
-        time=time if time is not None else None,
-        qpos=qpos if qpos is not None else [],
-        qvel=qvel if qvel is not None else [],
-        act=act if act is not None else [],
-        mocap_pos=mocap_pos if mocap_pos is not None else [],
-        mocap_quat=mocap_quat if mocap_quat is not None else [],
-        userdata=userdata if userdata is not None else [],
-    )
+    def close(self):
+        self.channel.close()
 
-    set_state_request = agent_pb2.SetStateRequest(state=state)
-    self.stub.SetState(set_state_request)
+        if self.server_process is not None:
+            self.server_process.kill()
+            self.server_process.wait()
 
-  def get_state(self) -> agent_pb2.State:
-    return self.stub.GetState(agent_pb2.GetStateRequest()).state
+    def init(
+        self,
+        task_id: str,
+        model: Optional[mujoco.MjModel] = None,
+        send_as: Literal["mjb", "xml"] = "xml",
+        real_time_speed: float = 1.0,
+    ):
+        """Initialize the agent for task `task_id`.
 
-  def get_action(
-      self,
-      time: Optional[float] = None,
-      averaging_duration: float = 0,
-      nominal_action: bool = False,
-  ) -> np.ndarray:
-    """Return latest `action` from the `Agent`'s planner.
+        Args:
+          task_id: the identifier for the MuJoCo MPC task, for example "Cartpole" or
+            "Humanoid Track".
+          model: optional `MjModel` instance, which, if provided, will be used as
+            the underlying model for planning. If not provided, the default MJPC
+            task xml will be used.
+          send_as: The serialization format for sending the model over gRPC. Either
+            "mjb" or "xml".
+          real_time_speed: ratio of running speed to wall clock, from 0 to 1. Only
+            affects async (UI) binaries, and not ones where planning is
+            synchronous.
+        """
 
-    Args:
-      time: `data.time`, i.e. the simulation time.
-      averaging_duration: the duration over which actions should be averaged
-        (e.g. the control timestep).
-      nominal_action: if True, don't apply feedback terms in the policy
+        def model_to_mjb(model: mujoco.MjModel) -> bytes:
+            buffer_size = mujoco.mj_sizeModel(model)
+            buffer = np.empty(shape=buffer_size, dtype=np.uint8)
+            mujoco.mj_saveModel(model, None, buffer)
+            return buffer.tobytes()
 
-    Returns:
-      action: `Agent`'s planner's latest action.
-    """
-    get_action_request = agent_pb2.GetActionRequest(
-        time=time,
-        averaging_duration=averaging_duration,
-        nominal_action=nominal_action,
-    )
-    get_action_response = self.stub.GetAction(get_action_request)
-    return np.array(get_action_response.action)
+        def model_to_xml(model: mujoco.MjModel) -> str:
+            tmp = tempfile.NamedTemporaryFile()
+            mujoco.mj_saveLastXML(tmp.name, model)
+            with pathlib.Path(tmp.name).open("rt") as f:
+                xml_string = f.read()
+            return xml_string
 
-  def get_total_cost(self) -> float:
-    terms = self.stub.GetCostValuesAndWeights(
-        agent_pb2.GetCostValuesAndWeightsRequest()
-    )
-    total_cost = 0
-    for _, value_weight in terms.values_weights.items():
-      total_cost += value_weight.weight * value_weight.value
-    return total_cost
+        if model is not None:
+            if send_as == "mjb":
+                model_message = agent_pb2.MjModel(mjb=model_to_mjb(model))
+            else:
+                model_message = agent_pb2.MjModel(xml=model_to_xml(model))
+        else:
+            model_message = None
 
-  def get_cost_term_values(self) -> dict[str, float]:
-    terms = self.stub.GetCostValuesAndWeights(
-        agent_pb2.GetCostValuesAndWeightsRequest()
-    )
-    return {
-        name: value_weight.value
-        for name, value_weight in terms.values_weights.items()
-    }
+        init_request = agent_pb2.InitRequest(task_id=task_id, model=model_message, real_time_speed=real_time_speed)
+        self.stub.Init(init_request)
 
-  def get_residuals(self) -> dict[str, Sequence[float]]:
-    residuals = self.stub.GetResiduals(agent_pb2.GetResidualsRequest())
-    return {name: residual.values
-            for name, residual in residuals.values.items()}
+    def set_state(
+        self,
+        time: Optional[float] = None,
+        qpos: Optional[npt.ArrayLike] = None,
+        qvel: Optional[npt.ArrayLike] = None,
+        act: Optional[npt.ArrayLike] = None,
+        mocap_pos: Optional[npt.ArrayLike] = None,
+        mocap_quat: Optional[npt.ArrayLike] = None,
+        userdata: Optional[npt.ArrayLike] = None,
+    ):
+        """Set `Agent`'s MuJoCo `data` state.
 
-  def planner_step(self):
-    """Send a planner request."""
-    planner_step_request = agent_pb2.PlannerStepRequest()
-    self.stub.PlannerStep(planner_step_request)
+        Args:
+          time: `data.time`, i.e. the simulation time.
+          qpos: `data.qpos`.
+          qvel: `data.qvel`.
+          act: `data.act`.
+          mocap_pos: `data.mocap_pos`.
+          mocap_quat: `data.mocap_quat`.
+          userdata: `data.userdata`.
+        """
+        # if mocap_pos is an ndarray rather than a list, flatten it
+        if hasattr(mocap_pos, "flatten"):
+            mocap_pos = mocap_pos.flatten()
+        if hasattr(mocap_quat, "flatten"):
+            mocap_quat = mocap_quat.flatten()
 
-  def step(self):
-    """Step the physics on the agent side."""
-    self.stub.Step(agent_pb2.StepRequest())
+        state = agent_pb2.State(
+            time=time if time is not None else None,
+            qpos=qpos if qpos is not None else [],
+            qvel=qvel if qvel is not None else [],
+            act=act if act is not None else [],
+            mocap_pos=mocap_pos if mocap_pos is not None else [],
+            mocap_quat=mocap_quat if mocap_quat is not None else [],
+            userdata=userdata if userdata is not None else [],
+        )
 
-  def reset(self):
-    """Reset the `Agent`'s data, settings, planner, and states."""
-    reset_request = agent_pb2.ResetRequest()
-    self.stub.Reset(reset_request)
+        set_state_request = agent_pb2.SetStateRequest(state=state)
+        self.stub.SetState(set_state_request)
 
-  def set_task_parameter(self, name: str, value: float):
-    """Set the `Agent`'s task parameters.
+    def get_state(self) -> agent_pb2.State:
+        return self.stub.GetState(agent_pb2.GetStateRequest()).state
 
-    Args:
-      name: the name to identify the parameter.
-      value: value to to set the parameter to.
-    """
-    self.set_task_parameters({name: value})
+    def get_action(
+        self,
+        time: Optional[float] = None,
+        averaging_duration: float = 0,
+        nominal_action: bool = False,
+    ) -> np.ndarray:
+        """Return latest `action` from the `Agent`'s planner.
 
-  def set_task_parameters(self, parameters: dict[str, float | str]):
-    """Sets the `Agent`'s task parameters.
+        Args:
+          time: `data.time`, i.e. the simulation time.
+          averaging_duration: the duration over which actions should be averaged
+            (e.g. the control timestep).
+          nominal_action: if True, don't apply feedback terms in the policy
 
-    Args:
-      parameters: a map from parameter name to value. string values will be
-          treated as "selection" values, i.e. parameters with names that start
-          with "residual_select_" in the XML.
-    """
-    request = agent_pb2.SetTaskParametersRequest()
-    for name, value in parameters.items():
-      if isinstance(value, str):
-        request.parameters[name].selection = value
-      else:
-        request.parameters[name].numeric = value
-    self.stub.SetTaskParameters(request)
+        Returns:
+          action: `Agent`'s planner's latest action.
+        """
+        get_action_request = agent_pb2.GetActionRequest(
+            time=time,
+            averaging_duration=averaging_duration,
+            nominal_action=nominal_action,
+        )
+        get_action_response = self.stub.GetAction(get_action_request)
+        return np.array(get_action_response.action)
 
-  def get_task_parameters(self) -> dict[str, float | str]:
-    """Returns the agent's task parameters."""
-    response = self.stub.GetTaskParameters(agent_pb2.GetTaskParametersRequest())
-    result = {}
-    for name, value in response.parameters.items():
-      if value.selection:
-        result[name] = value.selection
-      else:
-        result[name] = value.numeric
-    return result
+    def get_total_cost(self) -> float:
+        terms = self.stub.GetCostValuesAndWeights(agent_pb2.GetCostValuesAndWeightsRequest())
+        total_cost = 0
+        for _, value_weight in terms.values_weights.items():
+            total_cost += value_weight.weight * value_weight.value
+        return total_cost
 
-  def set_cost_weights(
-      self, weights: dict[str, float], reset_to_defaults: bool = False
-  ):
-    """Sets the agent's cost weights by name.
+    def get_cost_term_values(self) -> dict[str, float]:
+        terms = self.stub.GetCostValuesAndWeights(agent_pb2.GetCostValuesAndWeightsRequest())
+        return {name: value_weight.value for name, value_weight in terms.values_weights.items()}
 
-    Args:
-      weights: a map for cost term name to weight value
-      reset_to_defaults: if true, cost weights will be reset before applying the
-        map
-    """
-    request = agent_pb2.SetCostWeightsRequest(
-        cost_weights=weights, reset_to_defaults=reset_to_defaults
-    )
-    self.stub.SetCostWeights(request)
+    def get_residuals(self) -> dict[str, Sequence[float]]:
+        residuals = self.stub.GetResiduals(agent_pb2.GetResidualsRequest())
+        return {name: residual.values for name, residual in residuals.values.items()}
 
-  def get_cost_weights(self) -> dict[str, float]:
-    """Returns the agent's cost weights."""
-    terms = self.stub.GetCostValuesAndWeights(
-        agent_pb2.GetCostValuesAndWeightsRequest()
-    )
-    return {
-        name: value_weight.weight
-        for name, value_weight in terms.values_weights.items()
-    }
+    def planner_step(self):
+        """Send a planner request."""
+        planner_step_request = agent_pb2.PlannerStepRequest()
+        self.stub.PlannerStep(planner_step_request)
 
-  def get_mode(self) -> str:
-    return self.stub.GetMode(agent_pb2.GetModeRequest()).mode
+    def step(self):
+        """Step the physics on the agent side."""
+        self.stub.Step(agent_pb2.StepRequest())
 
-  def set_mode(self, mode: str):
-    request = agent_pb2.SetModeRequest(mode=mode)
-    self.stub.SetMode(request)
+    def reset(self):
+        """Reset the `Agent`'s data, settings, planner, and states."""
+        reset_request = agent_pb2.ResetRequest()
+        self.stub.Reset(reset_request)
 
-  def get_all_modes(self) -> Sequence[str]:
-    return self.stub.GetAllModes(agent_pb2.GetAllModesRequest()).mode_names
+    def set_task_parameter(self, name: str, value: float):
+        """Set the `Agent`'s task parameters.
 
-  def set_parameters(self, parameters: mjpc_parameters.MjpcParameters):
-    # TODO(nimrod): Add a single RPC that does this
-    if parameters.mode is not None:
-      self.set_mode(parameters.mode)
-    if parameters.task_parameters:
-      self.set_task_parameters(parameters.task_parameters)
-    if parameters.cost_weights:
-      self.set_cost_weights(parameters.cost_weights)
+        Args:
+          name: the name to identify the parameter.
+          value: value to to set the parameter to.
+        """
+        self.set_task_parameters({name: value})
 
-  def best_trajectory(self):
-    request = agent_pb2.GetBestTrajectoryRequest()
-    response = self.stub.GetBestTrajectory(request)
-    if self.model is None:
-      raise ValueError("model is None")
-    else:
-      return {
-          "states": np.array(response.states).reshape(
-              response.steps,
-              self.model.nq + self.model.nv + self.model.na,
-          ),
-          "actions": np.array(response.actions).reshape(
-              response.steps - 1, self.model.nu
-          ),
-          "times": np.array(response.times),
-      }
+    def set_task_parameters(self, parameters: dict[str, float | str]):
+        """Sets the `Agent`'s task parameters.
 
-  def set_mocap(self, mocap_map: Mapping[str, mjpc_parameters.Pose]):
-    request = agent_pb2.SetAnythingRequest()
-    for key, value in mocap_map.items():
-      if value.pos is not None:
-        request.mocap[key].pos.extend(value.pos)
-      if value.quat is not None:
-        request.mocap[key].quat.extend(value.quat)
-    self.stub.SetAnything(request)
+        Args:
+          parameters: a map from parameter name to value. string values will be
+              treated as "selection" values, i.e. parameters with names that start
+              with "residual_select_" in the XML.
+        """
+        request = agent_pb2.SetTaskParametersRequest()
+        for name, value in parameters.items():
+            if isinstance(value, str):
+                request.parameters[name].selection = value
+            else:
+                request.parameters[name].numeric = value
+        self.stub.SetTaskParameters(request)
+
+    def get_task_parameters(self) -> dict[str, float | str]:
+        """Returns the agent's task parameters."""
+        response = self.stub.GetTaskParameters(agent_pb2.GetTaskParametersRequest())
+        result = {}
+        for name, value in response.parameters.items():
+            if value.selection:
+                result[name] = value.selection
+            else:
+                result[name] = value.numeric
+        return result
+
+    def get_policy_parameters(self) -> np.ndarray:
+        """Returns the agent's policy parameters."""
+        response = self.stub.GetPolicyParameters(agent_pb2.GetPolicyParametersRequest())
+        return np.array(response.policy_parameters)
+
+    def set_cost_weights(self, weights: dict[str, float], reset_to_defaults: bool = False):
+        """Sets the agent's cost weights by name.
+
+        Args:
+          weights: a map for cost term name to weight value
+          reset_to_defaults: if true, cost weights will be reset before applying the
+            map
+        """
+        request = agent_pb2.SetCostWeightsRequest(cost_weights=weights, reset_to_defaults=reset_to_defaults)
+        self.stub.SetCostWeights(request)
+
+    def get_cost_weights(self) -> dict[str, float]:
+        """Returns the agent's cost weights."""
+        terms = self.stub.GetCostValuesAndWeights(agent_pb2.GetCostValuesAndWeightsRequest())
+        return {name: value_weight.weight for name, value_weight in terms.values_weights.items()}
+
+    def get_mode(self) -> str:
+        return self.stub.GetMode(agent_pb2.GetModeRequest()).mode
+
+    def set_mode(self, mode: str):
+        request = agent_pb2.SetModeRequest(mode=mode)
+        self.stub.SetMode(request)
+
+    def get_all_modes(self) -> Sequence[str]:
+        return self.stub.GetAllModes(agent_pb2.GetAllModesRequest()).mode_names
+
+    def set_parameters(self, parameters: mjpc_parameters.MjpcParameters):
+        # TODO(nimrod): Add a single RPC that does this
+        if parameters.mode is not None:
+            self.set_mode(parameters.mode)
+        if parameters.task_parameters:
+            self.set_task_parameters(parameters.task_parameters)
+        if parameters.cost_weights:
+            self.set_cost_weights(parameters.cost_weights)
+
+    def best_trajectory(self):
+        request = agent_pb2.GetBestTrajectoryRequest()
+        response = self.stub.GetBestTrajectory(request)
+        if self.model is None:
+            raise ValueError("model is None")
+        else:
+            return {
+                "states": np.array(response.states).reshape(
+                    response.steps,
+                    self.model.nq + self.model.nv + self.model.na,
+                ),
+                "actions": np.array(response.actions).reshape(response.steps - 1, self.model.nu),
+                "times": np.array(response.times),
+            }
+
+    def set_mocap(self, mocap_map: Mapping[str, mjpc_parameters.Pose]):
+        request = agent_pb2.SetAnythingRequest()
+        for key, value in mocap_map.items():
+            if value.pos is not None:
+                request.mocap[key].pos.extend(value.pos)
+            if value.quat is not None:
+                request.mocap[key].quat.extend(value.quat)
+        self.stub.SetAnything(request)

--- a/python/mujoco_mpc/demos/agent/cartpole.py
+++ b/python/mujoco_mpc/demos/agent/cartpole.py
@@ -52,12 +52,15 @@ print("Parameters:", agent.get_task_parameters())
 
 # %%
 # rollout horizon
-T = 150
+T = 1500
 
 # trajectories
 qpos = np.zeros((model.nq, T))
 qvel = np.zeros((model.nv, T))
 ctrl = np.zeros((model.nu, T - 1))
+# TODO(pculbert): add request for number of spline parameters.
+NUM_KNOT_POINTS = 10
+policy_parameters = np.zeros((model.nu, NUM_KNOT_POINTS, T - 1))
 time = np.zeros(T)
 
 # costs
@@ -101,6 +104,11 @@ for t in range(T - 1):
     data.ctrl = agent.get_action()
     ctrl[:, t] = data.ctrl
 
+    # set policy parameters
+    ### NEW BINDING ###
+    policy_parameters[:, :, t] = agent.get_policy_parameters().reshape(model.nu, NUM_KNOT_POINTS)
+    ###################
+
     # get costs
     cost_total[t] = agent.get_total_cost()
     for i, c in enumerate(agent.get_cost_term_values().items()):
@@ -119,8 +127,13 @@ for t in range(T - 1):
     pixels = renderer.render()
     frames.append(pixels)
 
+    # Store current poli
+
 # reset
 agent.reset()
+
+#### NEW BINDING ####
+
 
 # display video
 SLOWDOWN = 0.5


### PR DESCRIPTION
### Overview 

Does what it says on the box. Modifies the `Policy` and `Planner` classes to support passing back spline parameters via a `GRPC` call. Also modifies the `Agent` class on the python side to handle the message construction/parsing.

### Testing
* Ran the demo script successfully and ensured the parameters were (a) non-zero and (b) seemed to make sense.